### PR TITLE
RHIROS-1058 Fix count in API List response

### DIFF
--- a/internal/api/docs/v1/openapi.json
+++ b/internal/api/docs/v1/openapi.json
@@ -98,6 +98,26 @@
               "minimum": 1,
               "maximum": 100
             }
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "Options are cluster, project, workload_type, workload, container, last_reported",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "last_reported"
+            }
+          },
+          {
+            "name": "order_how",
+            "in": "query",
+            "description": "Options are ASC, DESC",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "example": "DESC"
+            }
           }
         ],
         "responses": {

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -102,7 +102,7 @@ func GetRecommendationSetList(c echo.Context) error {
 	log.Info("============================")
 	log.Infof("User orgID = %s", OrgID)
 	log.Info("============================")
-	recommendationSets, error := recommendationSet.GetRecommendationSets(OrgID, orderQuery, limit, offset, queryParams)
+	recommendationSets, count, error := recommendationSet.GetRecommendationSets(OrgID, orderQuery, limit, offset, queryParams)
 	log.Info("============================")
 	log.Infof("recommendationSets got from DB = %v", recommendationSets)
 	log.Info("============================")
@@ -144,7 +144,7 @@ func GetRecommendationSetList(c echo.Context) error {
 	for i, v := range allRecommendations {
 		interfaceSlice[i] = v
 	}
-	results := CollectionResponse(interfaceSlice, c.Request(), len(allRecommendations), limit, offset)
+	results := CollectionResponse(interfaceSlice, c.Request(), count, limit, offset)
 	log.Info("============================")
 	log.Infof("Data we are sending in response = %+v", results)
 	log.Info("============================")


### PR DESCRIPTION
The count value currently returns the number of records present in API response.

This should be the actual number of records on database with filters (if present).
