### PR TITLE
RHIROS-1061  Multiple filters on API fix

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -124,44 +124,54 @@ var seedCmd = &cobra.Command{
 
 		workload1 := &model.Workload{
 			Cluster:        *cluster1,
-			ExperimentName: "exfoo1",
+			ExperimentName: "exfoo",
 			Namespace:      "a_proj_rxu",
 			WorkloadType:   workload.Replicaset,
 			WorkloadName:   "replicaset_proj_rxu",
 			Containers:     []string{"node", "postgres", "apache"},
 		}
-		db.FirstOrCreate(&workload1)
+		db.Where(&model.Workload{Namespace: "a_proj_rxu"}).FirstOrCreate(&workload1)
 
 		workload2 := &model.Workload{
-			Cluster:        *cluster2,
-			ExperimentName: "exfoo2",
+			Cluster:        *cluster1,
+			ExperimentName: "exbar",
 			Namespace:      "b_proj_rxu",
+			WorkloadType:   workload.Statefulsets,
+			WorkloadName:   "stateful_proj_rxu",
+			Containers:     []string{"redis", "nginx"},
+		}
+		db.Where(&model.Workload{WorkloadType: workload.Statefulsets}).FirstOrCreate(&workload2)
+
+		workload3 := &model.Workload{
+			Cluster:        *cluster2,
+			ExperimentName: "exapp",
+			Namespace:      "c_proj_rxu",
 			WorkloadType:   workload.Deployment,
 			WorkloadName:   "deployment_proj_rxu",
 			Containers:     []string{"node", "postgres", "apache"},
 		}
-		db.Where(&model.Workload{WorkloadType: workload.Deployment}).FirstOrCreate(&workload2)
+		db.Where(&model.Workload{WorkloadType: workload.Deployment}).FirstOrCreate(&workload3)
 
 		recommendationSetData1 := map[string]interface{}{
 			"duration_based": map[string]interface{}{
 				"long_term": map[string]interface{}{
 					"config": map[string]interface{}{
 						"limits": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 						"requests": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 					},
 					"notifications": []map[string]interface{}{
 						{
-							"type": "info",
+							"type":    "info",
 							"message": "There is not enough data available to generate a recommendation.",
 						},
 					},
-					"monitoring_end_time": "0001-01-01T00:00:00Z",
+					"monitoring_end_time":   "0001-01-01T00:00:00Z",
 					"monitoring_start_time": "0001-01-01T00:00:00Z",
 				},
 				"short_term": map[string]interface{}{
@@ -187,32 +197,32 @@ var seedCmd = &cobra.Command{
 							},
 						},
 					},
-					"duration_in_hours": 0.23333333333333334,
-					"monitoring_end_time": "2023-04-02T00:15:00Z",
+					"duration_in_hours":     0.23333333333333334,
+					"monitoring_end_time":   "2023-04-02T00:15:00Z",
 					"monitoring_start_time": "2023-04-01T00:15:00Z",
 				},
 				"medium_term": map[string]interface{}{
 					"config": map[string]interface{}{
 						"limits": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 						"requests": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 					},
 					"notifications": []map[string]interface{}{
 						{
-							"type": "info",
+							"type":    "info",
 							"message": "There is not enough data available to generate a recommendation.",
 						},
 					},
-					"monitoring_end_time": "0001-01-01T00:00:00Z",
+					"monitoring_end_time":   "0001-01-01T00:00:00Z",
 					"monitoring_start_time": "0001-01-01T00:00:00Z",
 				},
 			},
-			"workload": "servers",
+			"workload":      "servers",
 			"workload_type": "deployment",
 		}
 
@@ -221,21 +231,21 @@ var seedCmd = &cobra.Command{
 				"long_term": map[string]interface{}{
 					"config": map[string]interface{}{
 						"limits": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 						"requests": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 					},
 					"notifications": []map[string]interface{}{
 						{
-							"type": "info",
+							"type":    "info",
 							"message": "There is not enough data available to generate a recommendation.",
 						},
 					},
-					"monitoring_end_time": "0001-01-01T00:00:00Z",
+					"monitoring_end_time":   "0001-01-01T00:00:00Z",
 					"monitoring_start_time": "0001-01-01T00:00:00Z",
 				},
 				"short_term": map[string]interface{}{
@@ -261,32 +271,32 @@ var seedCmd = &cobra.Command{
 							},
 						},
 					},
-					"duration_in_hours": 0.23333333333333334,
-					"monitoring_end_time": "2023-04-02T00:15:00Z",
+					"duration_in_hours":     0.23333333333333334,
+					"monitoring_end_time":   "2023-04-02T00:15:00Z",
 					"monitoring_start_time": "2023-04-01T00:15:00Z",
 				},
 				"medium_term": map[string]interface{}{
 					"config": map[string]interface{}{
 						"limits": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 						"requests": map[string]interface{}{
-							"cpu": map[string]interface{}{},
+							"cpu":    map[string]interface{}{},
 							"memory": map[string]interface{}{},
 						},
 					},
 					"notifications": []map[string]interface{}{
 						{
-							"type": "info",
+							"type":    "info",
 							"message": "There is not enough data available to generate a recommendation.",
 						},
 					},
-					"monitoring_end_time": "0001-01-01T00:00:00Z",
+					"monitoring_end_time":   "0001-01-01T00:00:00Z",
 					"monitoring_start_time": "0001-01-01T00:00:00Z",
 				},
 			},
-			"workload": "servers",
+			"workload":      "servers",
 			"workload_type": "replicaset",
 		}
 
@@ -308,7 +318,7 @@ var seedCmd = &cobra.Command{
 			Recommendations:     datatypes.JSON(jsonrecommendationSetData1),
 			UpdatedAt:           time.Now(),
 		}
-		db.FirstOrCreate(&recommendationSet1)
+		db.Where(&model.RecommendationSet{Recommendations: jsonrecommendationSetData1}).FirstOrCreate(&recommendationSet1)
 
 		recommendationSet2 := &model.RecommendationSet{
 			Workload:            *workload1,
@@ -321,14 +331,35 @@ var seedCmd = &cobra.Command{
 		db.Where(&model.RecommendationSet{Recommendations: jsonrecommendationSetData2}).FirstOrCreate(&recommendationSet2)
 
 		recommendationSet3 := &model.RecommendationSet{
-			Workload:            *workload2,
-			ContainerName:       "nodejs",
+			Workload:            *workload1,
+			ContainerName:       "hadoop",
 			MonitoringStartTime: time.Now().Add(-time.Hour * 3),
 			MonitoringEndTime:   time.Now().Add(-time.Hour * 2),
 			Recommendations:     datatypes.JSON(jsonrecommendationSetData2),
 			UpdatedAt:           time.Now(),
 		}
-		db.Where(&model.RecommendationSet{ContainerName: "nodejs"}).FirstOrCreate(&recommendationSet3)
+		db.Where(&model.RecommendationSet{ContainerName: "hadoop"}).FirstOrCreate(&recommendationSet3)
+
+		recommendationSet4 := &model.RecommendationSet{
+			Workload:            *workload2,
+			ContainerName:       "nginx",
+			MonitoringStartTime: time.Now().Add(-time.Hour * 3),
+			MonitoringEndTime:   time.Now().Add(-time.Hour * 2),
+			Recommendations:     datatypes.JSON(jsonrecommendationSetData2),
+			UpdatedAt:           time.Now(),
+		}
+		db.Where(&model.RecommendationSet{ContainerName: "nginx"}).FirstOrCreate(&recommendationSet4)
+
+		recommendationSet5 := &model.RecommendationSet{
+			Workload:            *workload3,
+			ContainerName:       "redis",
+			MonitoringStartTime: time.Now().Add(-time.Hour * 3),
+			MonitoringEndTime:   time.Now().Add(-time.Hour * 2),
+			Recommendations:     datatypes.JSON(jsonrecommendationSetData2),
+			UpdatedAt:           time.Now(),
+		}
+		db.Where(&model.RecommendationSet{ContainerName: "redis"}).FirstOrCreate(&recommendationSet5)
+
 	},
 }
 


### PR DESCRIPTION
DB Query from stage:

```
SELECT "recommendation_sets"."id","recommendation_sets"."workload_id","recommendation_sets"."container_name","recommendation_sets"."monitoring_start_time","recommendation_sets"."monitoring_end_time","recommendation_sets"."recommendations","recommendation_sets"."updated_at" FROM "recommendation_sets"
		JOIN (
			SELECT workload_id, MAX(monitoring_end_time) AS latest_monitoring_end_time
			FROM recommendation_sets GROUP BY workload_id
		) latest_rs ON recommendation_sets.workload_id = latest_rs.workload_id
				AND recommendation_sets.monitoring_end_time = latest_rs.latest_monitoring_end_time
			JOIN workloads ON recommendation_sets.workload_id = workloads.id
			JOIN clusters ON workloads.cluster_id = clusters.id
			JOIN rh_accounts ON clusters.tenant_id = rh_accounts.id
		 WHERE rh_accounts.org_id = '*********' AND DATE(recommendation_sets.monitoring_start_time) >= '2023-04-01' AND DATE(recommendation_sets.monitoring_end_time) <= '2023-04-12' AND clusters.cluster_alias LIKE '%iam%' OR clusters.cluster_uuid LIKE '%iam%' AND workloads.workload_name LIKE '%servers%' ORDER BY clusters.last_reported_at DESC LIMIT 10
```

Changes here,

```
SELECT "recommendation_sets"."id","recommendation_sets"."workload_id","recommendation_sets"."container_name","recommendation_sets"."monitoring_start_time","recommendation_sets"."monitoring_end_time","recommendation_sets"."recommendations","recommendation_sets"."updated_at" FROM "recommendation_sets" 
		JOIN (
			SELECT workload_id, MAX(monitoring_end_time) AS latest_monitoring_end_time 
			FROM recommendation_sets GROUP BY workload_id, container_name
		) latest_rs ON recommendation_sets.workload_id = latest_rs.workload_id 
				AND recommendation_sets.monitoring_end_time = latest_rs.latest_monitoring_end_time
			JOIN workloads ON recommendation_sets.workload_id = workloads.id
			JOIN clusters ON workloads.cluster_id = clusters.id
			JOIN rh_accounts ON clusters.tenant_id = rh_accounts.id
		 WHERE rh_accounts.org_id = '3340851' AND workloads.namespace LIKE '%a_proj%' AND workloads.workload_type = 'replicaset' AND DATE(recommendation_sets.monitoring_start_time) >= '2023-04-01' AND DATE(recommendation_sets.monitoring_end_time) <= '2023-04-12' AND (clusters.cluster_alias LIKE '%Foo%' OR clusters.cluster_uuid LIKE '%Foo%') ORDER BY recommendation_sets.container_name ASC LIMIT 1 OFFSET 1

```
**Note:** The **parenthesis** around `clusters.cluster_alias LIKE '%Foo%' OR clusters.cluster_uuid LIKE '%Foo%'`

The `OR` condition wasn't contained and was interfering with the subsequent `AND` 