### PR TITLE
Change rbac protocol to http

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -90,7 +90,7 @@ func initConfig() {
 			if endpoint.App == "rbac" {
 				viper.SetDefault("RBACHost", endpoint.Hostname)
 				viper.SetDefault("RBACPort", endpoint.Port)
-				viper.SetDefault("RBACProtocol", "https")
+				viper.SetDefault("RBACProtocol", "http")
 				viper.SetDefault("RBACEnabled", true)
 			}
 		}


### PR DESCRIPTION
RBAC connection failing in stage with below error - 
```
time="2023-04-22T06:57:03Z" level=error msg="error Occured while calling RBAC API Get \"https://rbac-service.rbac-stage.svc:8000/api/rbac/v1/access/?application=cost-management&limit=100\": net/http: TLS handshake timeout" func=github.com/redhatinsights/ros-ocp-backend/internal/api/middleware.request_user_access file="/go/src/app/internal/api/middleware/rbac.go:95"
```

Looking at few other service I think we do not use `https` connection for internal services.  