### PR TITLE
Removed rbac check from handler

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/redhatinsights/ros-ocp-backend/internal/model"
-	"github.com/redhatinsights/ros-ocp-backend/internal/types"
 )
 
 var variationDummyObject = map[string]interface{}{
@@ -91,13 +90,6 @@ func GetRecommendationSetList(c echo.Context) error {
 		if err == nil {
 			offset = offsetInt
 		}
-	}
-
-	if !is_user_authorized_for_resource(types.ResourceObject{
-		Cluster: c.QueryParam("cluster"),
-		Project: c.QueryParam("project"),
-	}, user_permissions) {
-		return c.JSON(http.StatusUnauthorized, "User is not authorized to access the resource")
 	}
 
 	queryParams := MapQueryParameters(c)


### PR DESCRIPTION
We need to remove rbac check from handler to support ILIKE(partial search). 
Example - If cluster name is `test_cost_ocp_ros_a619e0e8` then this API should should work - `api/cost-management/v1/recommendations/openshift?cluster=test_cost`

Also in UI when user apply filter like - `api/cost-management/v1/recommendations/openshift?project=anything` then we should output blank result instead of saying `User is not authorized to access the resource`