### PR TITLE
RHIROS-1081 Additonal keys in openapi

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -360,6 +360,14 @@
                         },
                         "nullable": true
                       },
+                      "pods_count": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "confidence_level": {
+                        "type": "number",
+                        "example": 0.5
+                      },
                       "duration_in_hours": {
                         "type": "number",
                         "example": 361
@@ -535,6 +543,14 @@
                           "nullable": true
                         }
                       },
+                      "pods_count": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "confidence_level": {
+                        "type": "number",
+                        "example": 0.5
+                      },
                       "duration_in_hours": {
                         "type": "number",
                         "example": 169
@@ -709,6 +725,14 @@
                           },
                           "nullable": true
                         }
+                      },
+                      "pods_count": {
+                        "type": "integer",
+                        "example": 1
+                      },
+                      "confidence_level": {
+                        "type": "number",
+                        "example": 0.5
                       },
                       "duration_in_hours": {
                         "type": "number",


### PR DESCRIPTION
Below keys needed for Recommendation object

- confidence_level
- pods_count

Source: https://github.com/kruize/autotune/blob/mvp_demo/design/MonitoringModeAPI.md