### PR TITLE
Fixes #RHIROS-1121 - omit metrics object if values not present

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+
+	"github.com/go-gota/gota/dataframe"
+	"github.com/spf13/cobra"
+)
+
+var validateCmd = &cobra.Command{Use: "validate", Short: "Validate ros related data"}
+
+var validateCSV = &cobra.Command{
+	Use:   "csv [input csv file path]",
+	Short: "Validate ros-usage CSV file",
+	Long:  "Validate ros-usage CSV file",
+	Run: func(cmd *cobra.Command, args []string) {
+		input_file := args[0]
+		if _, err := os.Stat(input_file); os.IsNotExist(err) {
+			fmt.Printf("CSV file: %s does not exist\n", input_file)
+			os.Exit(1)
+		}
+		f, err := os.Open(input_file)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer f.Close()
+
+		csv := csv.NewReader(f)
+		records, err := csv.ReadAll()
+		if err != nil {
+			panic(err.Error())
+		}
+
+		df := dataframe.LoadRecords(records)
+		groups := df.GroupBy("container_name", "pod", "owner_name", "owner_kind", "workload", "workload_type", "namespace", "image_name").GetGroups()
+
+		// for _, v := range groups {
+		// 	if v.Nrow() > 26 {
+		// 		sorted := v.Arrange(
+		// 			dataframe.Sort("interval_start"),
+		// 		)
+		// 		for _, data := range sorted.Maps() {
+		// 			asd, _ := utils.ConvertStringToTime(data["interval_start"].(string))
+		// 			fmt.Println(asd)
+		// 		}
+		// 	}
+		// }
+
+		valid_experiments := 0
+		for _, v := range groups {
+			if v.Nrow() > 26 {
+				valid_experiments = valid_experiments + 1
+			}
+		}
+		if valid_experiments > 0 {
+			fmt.Printf("Number of valid experiments - %v \n", valid_experiments)
+		} else {
+			fmt.Println("No valid experiments found")
+		}
+
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(validateCmd)
+	validateCmd.AddCommand(validateCSV)
+}

--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -224,7 +224,7 @@ func make_container_data(c map[string]interface{}) container {
 	// memoryRSS
 	sum = convertMetricToString(c["memory_rss_usage_container_sum_SUM"])
 	avg = convertMetricToString(c["memory_rss_usage_container_avg_MEAN"])
-	max = convertMetricToString(c["memory_rss_usage_container_min_MIN"])
+	max = convertMetricToString(c["memory_rss_usage_container_max_MAX"])
 	min = convertMetricToString(c["memory_rss_usage_container_min_MIN"])
 	if sum != "" && avg != "" {
 		metrics = append(metrics, metric{

--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -91,103 +91,160 @@ func convertMetricToString(data interface{}) string {
 	if metric, ok := data.(float64); ok {
 		return fmt.Sprintf("%.2f", metric)
 	} else {
-		return "-1"
+		return ""
 	}
 }
 
 func make_container_data(c map[string]interface{}) container {
+
+	metrics := []metric{}
+
+	// cpuRequest
+	sum := convertMetricToString(c["cpu_request_container_sum_SUM"])
+	avg := convertMetricToString(c["cpu_request_container_avg_MEAN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "cpuRequest",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Sum:    sum,
+					Avg:    avg,
+					Format: "cores",
+				},
+			},
+		})
+	}
+
+	// cpuLimit
+	sum = convertMetricToString(c["cpu_limit_container_sum_SUM"])
+	avg = convertMetricToString(c["cpu_limit_container_avg_MEAN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "cpuLimit",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Sum:    sum,
+					Avg:    avg,
+					Format: "cores",
+				},
+			},
+		})
+	}
+
+	// cpuUsage
+	sum = convertMetricToString(c["cpu_usage_container_sum_SUM"])
+	avg = convertMetricToString(c["cpu_usage_container_avg_MEAN"])
+	max := convertMetricToString(c["cpu_usage_container_max_MAX"])
+	min := convertMetricToString(c["cpu_usage_container_min_MIN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "cpuUsage",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Min:    min,
+					Max:    max,
+					Sum:    sum,
+					Avg:    avg,
+					Format: "cores",
+				},
+			},
+		})
+	}
+
+	// cpuThrottle
+	sum = convertMetricToString(c["cpu_throttle_container_sum_SUM"])
+	avg = convertMetricToString(c["cpu_throttle_container_avg_MEAN"])
+	max = convertMetricToString(c["cpu_throttle_container_max_MAX"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "cpuThrottle",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Max:    max,
+					Sum:    sum,
+					Avg:    avg,
+					Format: "cores",
+				},
+			},
+		})
+	}
+
+	// memoryRequest
+	sum = convertMetricToString(c["memory_request_container_sum_SUM"])
+	avg = convertMetricToString(c["memory_request_container_avg_MEAN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "memoryRequest",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Sum:    sum,
+					Avg:    avg,
+					Format: "MiB",
+				},
+			},
+		})
+	}
+
+	// memoryLimit
+	sum = convertMetricToString(c["memory_limit_container_sum_SUM"])
+	avg = convertMetricToString(c["memory_limit_container_avg_MEAN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "memoryLimit",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Sum:    sum,
+					Avg:    avg,
+					Format: "MiB",
+				},
+			},
+		})
+	}
+
+	// memoryUsage
+	sum = convertMetricToString(c["memory_usage_container_sum_SUM"])
+	avg = convertMetricToString(c["memory_usage_container_avg_MEAN"])
+	min = convertMetricToString(c["memory_usage_container_min_MIN"])
+	max = convertMetricToString(c["memory_usage_container_max_MAX"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "memoryUsage",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Min:    min,
+					Max:    max,
+					Sum:    sum,
+					Avg:    avg,
+					Format: "MiB",
+				},
+			},
+		})
+	}
+
+	// memoryRSS
+	sum = convertMetricToString(c["memory_rss_usage_container_sum_SUM"])
+	avg = convertMetricToString(c["memory_rss_usage_container_avg_MEAN"])
+	max = convertMetricToString(c["memory_rss_usage_container_min_MIN"])
+	min = convertMetricToString(c["memory_rss_usage_container_min_MIN"])
+	if sum != "" && avg != "" {
+		metrics = append(metrics, metric{
+			Name: "memoryRSS",
+			Results: result{
+				Aggregation_info: aggregation_info{
+					Min:    min,
+					Max:    max,
+					Sum:    sum,
+					Avg:    avg,
+					Format: "MiB",
+				},
+			},
+		})
+	}
+
 	container_data := container{
 		Container_image_name: c["image_name"].(string),
 		Container_name:       c["container_name"].(string),
-		Metrics: []metric{
-			{
-				Name: "cpuRequest",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Sum:    convertMetricToString(c["cpu_request_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["cpu_request_container_avg_MEAN"]),
-						Format: "cores",
-					},
-				},
-			},
-			{
-				Name: "cpuLimit",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Sum:    convertMetricToString(c["cpu_limit_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["cpu_limit_container_avg_MEAN"]),
-						Format: "cores",
-					},
-				},
-			},
-			{
-				Name: "cpuUsage",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Min:    convertMetricToString(c["cpu_usage_container_min_MIN"]),
-						Max:    convertMetricToString(c["cpu_usage_container_max_MAX"]),
-						Sum:    convertMetricToString(c["cpu_usage_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["cpu_usage_container_avg_MEAN"]),
-						Format: "cores",
-					},
-				},
-			},
-			{
-				Name: "cpuThrottle",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Max:    convertMetricToString(c["cpu_throttle_container_max_MAX"]),
-						Sum:    convertMetricToString(c["cpu_throttle_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["cpu_throttle_container_avg_MEAN"]),
-						Format: "cores",
-					},
-				},
-			},
-			{
-				Name: "memoryRequest",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Sum:    convertMetricToString(c["memory_request_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["memory_request_container_avg_MEAN"]),
-						Format: "MiB",
-					},
-				},
-			},
-			{
-				Name: "memoryLimit",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Sum:    convertMetricToString(c["memory_limit_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["memory_limit_container_avg_MEAN"]),
-						Format: "MiB",
-					},
-				},
-			},
-			{
-				Name: "memoryUsage",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Min:    convertMetricToString(c["memory_usage_container_min_MIN"]),
-						Max:    convertMetricToString(c["memory_usage_container_max_MAX"]),
-						Sum:    convertMetricToString(c["memory_usage_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["memory_usage_container_avg_MEAN"]),
-						Format: "MiB",
-					},
-				},
-			},
-			{
-				Name: "memoryRSS",
-				Results: result{
-					Aggregation_info: aggregation_info{
-						Min:    convertMetricToString(c["memory_rss_usage_container_min_MIN"]),
-						Max:    convertMetricToString(c["memory_rss_usage_container_max_MAX"]),
-						Sum:    convertMetricToString(c["memory_rss_usage_container_sum_SUM"]),
-						Avg:    convertMetricToString(c["memory_rss_usage_container_avg_MEAN"]),
-						Format: "MiB",
-					},
-				},
-			},
-		},
+		Metrics:              metrics,
 	}
 
 	return container_data


### PR DESCRIPTION
Kruize expects that if user has not set the cpu/memory requests and limits then we should omit that object from json payload. 
Currently we are sending -1. 