### PR TITLE
Point testing plugin in clowdapp

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -184,6 +184,8 @@ objects:
         partitions: 1
       - topicName: rosocp.kruize.experiments
         partitions: 1
+    testing:
+      iqePlugin: ros-ocp
 
 parameters:
 - description : ClowdEnvironment name


### PR DESCRIPTION
it will help us to debug the pr_check.sh integration test run. 

We need to tell clowder deployment to use this plugin so that we cand deploy the application and spin iqe-pod for further debugging. 
