### PR TITLE
RHIROS-1146 Report processor exits on Create failures

### DIFF
--- a/internal/services/report_processor.go
+++ b/internal/services/report_processor.go
@@ -131,7 +131,7 @@ func ProcessReport(msg *kafka.Message) {
 			}
 			if err := workload.CreateWorkload(); err != nil {
 				log.Errorf("unable to get or add record to workloads table: %v. Error: %v", workload, err)
-				return
+				continue
 			}
 
 			usage_data_byte, err := kruize.Update_results(experiment_name, k8s_object)
@@ -154,7 +154,7 @@ func ProcessReport(msg *kafka.Message) {
 				}
 				if err := workload_metric.CreateWorkloadMetrics(); err != nil {
 					log.Errorf("unable to add record to workload_metrics table: %v. Error: %v", workload_metric, err)
-					return
+					continue
 				}
 			}
 

--- a/internal/services/report_processor.go
+++ b/internal/services/report_processor.go
@@ -187,6 +187,6 @@ func ProcessReport(msg *kafka.Message) {
 		}
 
 	}
-	log.Infof("Total records upload to rosocp.kruize.experiments = %v", record_counter)
+	log.Infof("Total workloads uploaded to rosocp.kruize.experiments = %v", record_counter)
 
 }


### PR DESCRIPTION
Changes:

Scenarios where-in code flow should not exit ~ `return` in case db record creation fails