### PR TITLE
RHIROS-1198 CPU: cores to millicores

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -262,7 +262,7 @@ var seedCmd = &cobra.Command{
 						},
 						"requests": map[string]interface{}{
 							"cpu": map[string]interface{}{
-								"amount": 0.05,
+								"amount": 0.578933223234234234,
 								"format": "cores",
 							},
 							"memory": map[string]interface{}{
@@ -274,7 +274,7 @@ var seedCmd = &cobra.Command{
 					"config": map[string]interface{}{
 						"limits": map[string]interface{}{
 							"cpu": map[string]interface{}{
-								"amount": 0.06,
+								"amount": 5.3678942352345234523424,
 								"format": "cores",
 							},
 							"memory": map[string]interface{}{
@@ -284,7 +284,7 @@ var seedCmd = &cobra.Command{
 						},
 						"requests": map[string]interface{}{
 							"cpu": map[string]interface{}{
-								"amount": 0.05,
+								"amount": 4.70,
 								"format": "cores",
 							},
 							"memory": map[string]interface{}{

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -89,7 +89,7 @@ func GetRecommendationSetList(c echo.Context) error {
 		recommendationData["workload"] = recommendation.Workload.WorkloadName
 		recommendationData["container"] = recommendation.ContainerName
 		recommendationData["last_reported"] = recommendation.Workload.Cluster.LastReportedAtStr
-		recommendationData["recommendations"] = UpdateRecommendationUnits(recommendation.Recommendations)
+		recommendationData["recommendations"] = TransformComponentUnits(recommendation.Recommendations)
 		allRecommendations = append(allRecommendations, recommendationData)
 
 	}
@@ -133,7 +133,7 @@ func GetRecommendationSet(c echo.Context) error {
 		recommendationSlice["workload"] = recommendationSet.Workload.WorkloadName
 		recommendationSlice["container"] = recommendationSet.ContainerName
 		recommendationSlice["last_reported"] = recommendationSet.Workload.Cluster.LastReportedAtStr
-		recommendationSlice["recommendations"] = UpdateRecommendationUnits(recommendationSet.Recommendations)
+		recommendationSlice["recommendations"] = TransformComponentUnits(recommendationSet.Recommendations)
 	}
 
 	return c.JSON(http.StatusOK, recommendationSlice)

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -89,7 +89,7 @@ func GetRecommendationSetList(c echo.Context) error {
 		recommendationData["workload"] = recommendation.Workload.WorkloadName
 		recommendationData["container"] = recommendation.ContainerName
 		recommendationData["last_reported"] = recommendation.Workload.Cluster.LastReportedAtStr
-		recommendationData["recommendations"] = UpdateMemoryFromBytesToMiB(recommendation.Recommendations)
+		recommendationData["recommendations"] = UpdateRecommendationUnits(recommendation.Recommendations)
 		allRecommendations = append(allRecommendations, recommendationData)
 
 	}
@@ -133,7 +133,7 @@ func GetRecommendationSet(c echo.Context) error {
 		recommendationSlice["workload"] = recommendationSet.Workload.WorkloadName
 		recommendationSlice["container"] = recommendationSet.ContainerName
 		recommendationSlice["last_reported"] = recommendationSet.Workload.Cluster.LastReportedAtStr
-		recommendationSlice["recommendations"] = UpdateMemoryFromBytesToMiB(recommendationSet.Recommendations)
+		recommendationSlice["recommendations"] = UpdateRecommendationUnits(recommendationSet.Recommendations)
 	}
 
 	return c.JSON(http.StatusOK, recommendationSlice)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -264,7 +264,7 @@ func TransformComponentUnits(jsonData datatypes.JSON) map[string]interface{} {
 		if ok {
 			if math.Abs(cpuInCores) < 1 {
 				cpuInMillicores := cpuInCores * 1000
-				cpu["amount"] = truncateToThreeDecimalPlaces(cpuInMillicores)
+				cpu["amount"] = math.Round(cpuInMillicores) // millicore values are rounded & don't require decimal precision
 				cpu["format"] = "millicores"
 			} else {
 				cpu["amount"] = truncateToThreeDecimalPlaces(cpuInCores)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -210,11 +210,11 @@ func get_user_permissions(c echo.Context) map[string][]string {
 	return user_permissions
 }
 
-func UpdateRecommendationUnits(jsonData datatypes.JSON) map[string]interface{} {
+func TransformComponentUnits(jsonData datatypes.JSON) map[string]interface{} {
 	/*
-	Converts units for Memory and CPU
-	bytes -> MiB -> GiB
-	cores -> millicores
+		Converts units for Memory and CPU
+		bytes -> MiB -> GiB
+		cores -> millicores
 	*/
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(jsonData), &data)
@@ -232,39 +232,37 @@ func UpdateRecommendationUnits(jsonData datatypes.JSON) map[string]interface{} {
 		amount, ok := memory["amount"].(float64)
 		if ok {
 			memoryInMiB := amount / 1024 / 1024
-			memory["amount"] = math.Trunc(memoryInMiB*100) / 100
-			memory["format"] = "MiB"
-			if memoryInMiB >= 1024 {
+			if math.Abs(memoryInMiB) >= 1024 {
 				memoryInGiB := memoryInMiB / 1024
 				memory["amount"] = math.Trunc(memoryInGiB*100) / 100
 				memory["format"] = "GiB"
+			} else {
+				memory["amount"] = math.Trunc(memoryInMiB*100) / 100
+				memory["format"] = "MiB"
 			}
 		}
 		return nil
 	}
 
 	hasMoreThanThreeDecimals := func(value float64) bool {
-		precision := 0.001
+		const decimalPrecision int = 3
 		str := strconv.FormatFloat(value, 'f', -1, 64)
 		decimalPart := strings.Split(str, ".")
-		if len(decimalPart) > 1 {
-			return len(decimalPart[1]) > int(math.Log10(1/precision)+1)
-		}
-		return false
+		return (len(decimalPart) > 1) && (len(decimalPart[1]) > decimalPrecision)
 	}
-	
+
 	truncateToThreeDecimalPlaces := func(value float64) float64 {
 		if hasMoreThanThreeDecimals(value) {
-			truncated := math.Trunc(value * 1000) // Pushes decimal by 3 places
+			truncated := math.Trunc(value * 1000) // Pushes decimal by 3 places and then truncates
 			return truncated / 1000
 		}
 		return value
 	}
-	
+
 	convertCPU := func(cpu map[string]interface{}) error {
 		cpuInCores, ok := cpu["amount"].(float64)
 		if ok {
-			if cpuInCores < 1 {
+			if math.Abs(cpuInCores) < 1 {
 				cpuInMillicores := cpuInCores * 1000
 				cpu["amount"] = truncateToThreeDecimalPlaces(cpuInMillicores)
 				cpu["format"] = "millicores"
@@ -275,7 +273,13 @@ func UpdateRecommendationUnits(jsonData datatypes.JSON) map[string]interface{} {
 		}
 		return nil
 	}
-	
+
+	/*
+		Recommendation data is available for three periods
+		For each of these actual values will be present in
+		below mentioned dataBlocks > request and limits
+	*/
+
 	for _, period := range []string{"long_term", "medium_term", "short_term"} {
 		intervalData, ok := durationBased[period].(map[string]interface{})
 		if !ok {
@@ -288,45 +292,29 @@ func UpdateRecommendationUnits(jsonData datatypes.JSON) map[string]interface{} {
 				continue
 			}
 
-			limits, ok := recommendationSection["limits"].(map[string]interface{})
-			if ok {
-				memory, ok := limits["memory"].(map[string]interface{})
-				if ok {
-					err := convertMemory(memory)
-					if err != nil {
-						fmt.Printf("error converting memory in %s: %v\n", period, err)
-						continue
-					}
-				}
-				cpu, ok := limits["cpu"].(map[string]interface{})
-				if ok {
-					err := convertCPU(cpu)
-					if err != nil {
-						fmt.Printf("error converting cpu in %s: %v\n", period, err)
-						continue
-					}
-				}
-			}
+			for _, section := range []string{"limits", "requests"} {
 
-			requests, ok := recommendationSection["requests"].(map[string]interface{})
-			if ok {
-				memory, ok := requests["memory"].(map[string]interface{})
+				sectionObject, ok := recommendationSection[section].(map[string]interface{})
 				if ok {
-					err := convertMemory(memory)
-					if err != nil {
-						fmt.Printf("error converting memory in %s: %v\n", period, err)
-						continue
+					memory, ok := sectionObject["memory"].(map[string]interface{})
+					if ok {
+						err := convertMemory(memory)
+						if err != nil {
+							fmt.Printf("error converting memory in %s: %v\n", period, err)
+							continue
+						}
 					}
-				}
-				cpu, ok := requests["cpu"].(map[string]interface{})
-				if ok {
-					err := convertCPU(cpu)
-					if err != nil {
-						fmt.Printf("error converting cpu in %s: %v\n", period, err)
-						continue
+					cpu, ok := sectionObject["cpu"].(map[string]interface{})
+					if ok {
+						err := convertCPU(cpu)
+						if err != nil {
+							fmt.Printf("error converting cpu in %s: %v\n", period, err)
+							continue
+						}
 					}
 				}
 			}	
+			
 		}
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -282,7 +282,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 2.09
+                                    "example": 2
                                   },
                                   "format": {
                                     "type": "string",
@@ -460,7 +460,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.02
+                                    "example": 3
                                   },
                                   "format": {
                                     "type": "string",
@@ -473,7 +473,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.959
+                                    "example": 344
                                   },
                                   "format": {
                                     "type": "string",
@@ -491,7 +491,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.01
+                                    "example": 4
                                   },
                                   "format": {
                                     "type": "string",
@@ -504,7 +504,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.005
+                                    "example": 500
                                   },
                                   "format": {
                                     "type": "string",
@@ -599,11 +599,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 2.11
+                                    "example": 622
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "cores"
+                                    "example": "millicores"
                                   }
                                 }
                               },
@@ -616,7 +616,7 @@
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "MiB"
+                                    "example": "GiB"
                                   }
                                 }
                               }
@@ -710,7 +710,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.02
+                                    "example": 2
                                   },
                                   "format": {
                                     "type": "string",
@@ -723,7 +723,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.959
+                                    "example": 959.4
                                   },
                                   "format": {
                                     "type": "string",
@@ -741,7 +741,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.01
+                                    "example": 5
                                   },
                                   "format": {
                                     "type": "string",
@@ -754,7 +754,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.005
+                                    "example": 200.333
                                   },
                                   "format": {
                                     "type": "string",
@@ -960,7 +960,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.02
+                                    "example": 5
                                   },
                                   "format": {
                                     "type": "string",
@@ -973,7 +973,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.959
+                                    "example": 929.111
                                   },
                                   "format": {
                                     "type": "string",
@@ -991,7 +991,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.01
+                                    "example": 3
                                   },
                                   "format": {
                                     "type": "string",
@@ -1004,7 +1004,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 0.005
+                                    "example": 500
                                   },
                                   "format": {
                                     "type": "string",


### PR DESCRIPTION
Convert values for CPU `cores` to `millicores` if values are less than 1

Additionally the agenda is to have 3 decimal places consistently.

### Cores -> Millicores

0.06 - 60
0.578933223234234234 - 579

### Cores -> Cores
5.3678942352345234523424 - 5.367
4.700 - 4.7

Please don't quote me on the validity of the values :stuck_out_tongue: 