### PR TITLE
RHIROS-1220 Kruize as ClowdApp kind

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -130,70 +130,6 @@ objects:
             value: "rosocp-api"
           - name: LOG_LEVEL
             value: ${LOG_LEVEL}
-    - name: kruize
-      replicas: ${{KRUIZE_REPLICA_COUNT}}
-      webServices:
-        private:
-          enabled: true
-      podSpec:
-        image: ${KRUIZE_IMAGE}:${KRUIZE_IMAGE_TAG}
-        command: ["sh"]
-        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && bash target/bin/Autotune"]
-        machinePool: ${MACHINE_POOL_OPTION}
-        resources:
-          requests:
-            cpu: ${KRUIZE_CPU_REQUEST}
-            memory: ${KRUIZE_MEMORY_REQUEST}
-          limits:
-            cpu: ${KRUIZE_CPU_LIMIT}
-            memory: ${KRUIZE_MEMORY_LIMIT}
-        env:
-          - name: AUTOTUNE_SERVER_PORT
-            value: ${KRUIZE_PORT}
-          - name: AUTH_TOKEN
-            value: ""
-          - name: LOGGING_LEVEL
-            value: "info"
-          - name: ROOT_LOGGING_LEVEL
-            value: "info"
-          - name: dbdriver
-            value: "jdbc:postgresql://"
-          - name: database_name
-            value: ${KRUIZE_DB_NAME}
-          - name: clustertype
-            value: "kubernetes"
-          - name: k8stype
-            value: "openshift"
-          - name: authtype
-            value: "openshift"
-          - name: monitoringagent
-            value: "prometheus"
-          - name: monitoringservice
-            value: "prometheus-k8s"
-          - name: monitoringendpoint
-            value: "prometheus-k8s"
-          - name: savetodb
-            value: "true"
-          - name: hibernate_dialect
-            value: "org.hibernate.dialect.PostgreSQLDialect"
-          - name: hibernate_driver
-            value: "org.postgresql.Driver"
-          - name: hibernate_c3p0minsize
-            value: "2"
-          - name: hibernate_c3p0maxsize
-            value: "5"
-          - name: hibernate_c3p0timeout
-            value: "300"
-          - name: hibernate_c3p0maxstatements
-            value: "50"
-          - name: hibernate_hbm2ddlauto
-            value: "update"
-          - name: hibernate_showsql
-            value: "false"
-          - name: hibernate_timezone
-            value: "UTC"
-          - name: SSL_CERT_DIR
-            value: ${SSL_CERT_DIR}
     database:
       name: rosocp
       version: 13
@@ -219,45 +155,10 @@ parameters:
 - description: Image tag
   name: IMAGE_TAG
   required: true
-- description: Kruize database name
-  name: KRUIZE_DB_NAME
-  required: true
-- description: Kruize image name
-  name: KRUIZE_IMAGE
-  required: true
-  value: quay.io/cloudservices/autotune
-- description: Kruize image tag
-  name: KRUIZE_IMAGE_TAG
-  required: true
-  value: "190a6cc"
 - description: Kruize server host
   name: KRUIZE_HOST
   required: true
   value: "ros-ocp-backend-kruize"
-- description: Kruize server port
-  name: KRUIZE_PORT
-  required: true
-  value: "10000"
-- description: Initial kruize cpu request.
-  displayName: KRUIZE CPU Request
-  name: KRUIZE_CPU_REQUEST
-  required: true
-  value: 500m
-- description: Initial amount of memory kruize container will request.
-  displayName: KRUIZE Memory Request
-  name: KRUIZE_MEMORY_REQUEST
-  required: true
-  value: 1Gi
-- description: Maximum amount of memory kruize container can use.
-  displayName: KRUIZE Memory Limit
-  name: KRUIZE_MEMORY_LIMIT
-  required: true
-  value: 1Gi
-- description: Maximum amount of CPU kruize container can use.
-  displayName: KRUIZE CPU Limit
-  name: KRUIZE_CPU_LIMIT
-  required: true
-  value: '1'
 - description: Initial cpu request.
   displayName: CPU Request
   name: CPU_REQUEST
@@ -292,9 +193,6 @@ parameters:
 - description: Time to wait before hitting listRecommendation API
   name: KRUIZE_WAIT_TIME
   value: "120"
-- description: Replica count for kruize pod
-  name: KRUIZE_REPLICA_COUNT
-  value: "1"
 - name: MACHINE_POOL_OPTION
   value: ''
 - description: Enable the RBAC

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -11,7 +11,6 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
-    - kruize
     - ingress
     - rbac
     deployments:

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -158,7 +158,11 @@ parameters:
 - description: Kruize server host
   name: KRUIZE_HOST
   required: true
-  value: "ros-ocp-backend-kruize"
+  value: "kruize-recommendations"
+- description: Kruize server port
+  name: KRUIZE_PORT
+  required: true
+  value: "10000"
 - description: Initial cpu request.
   displayName: CPU Request
   name: CPU_REQUEST

--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -11,6 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
+    - kruize
     - ingress
     - rbac
     deployments:

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -29,6 +29,8 @@ objects:
             cpu: ${KRUIZE_CPU_LIMIT}
             memory: ${KRUIZE_MEMORY_LIMIT}
         env:
+          - name: CLOWDER_ENABLED
+            value: ${CLOWDER_ENABLED}
           - name: AUTOTUNE_SERVER_PORT
             value: ${KRUIZE_PORT}
           - name: AUTH_TOKEN
@@ -39,8 +41,6 @@ objects:
             value: "info"
           - name: dbdriver
             value: "jdbc:postgresql://"
-          - name: database_name
-            value: ${KRUIZE_DB_NAME}
           - name: clustertype
             value: "kubernetes"
           - name: k8stype
@@ -76,19 +76,16 @@ objects:
           - name: SSL_CERT_DIR
             value: ${SSL_CERT_DIR}
     database:
-      name: kruize
+      name: postgres
       version: 13
-    testing:
-      iqePlugin: ros-ocp
 
 parameters:
 - description : ClowdEnvironment name
   name: ENV_NAME
   required: true
-- description: Kruize database name
-  name: KRUIZE_DB_NAME
-  required: true
-  value: "kruize"
+- description: Is clowder enabled
+  name: CLOWDER_ENABLED
+  value: "True"
 - description: Kruize image name
   name: KRUIZE_IMAGE
   required: true

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -11,7 +11,7 @@ objects:
   spec:
     envName: ${ENV_NAME}
     deployments:
-    - name: kruize
+    - name: recommendations
       replicas: ${{KRUIZE_REPLICA_COUNT}}
       webServices:
         private:
@@ -97,10 +97,6 @@ parameters:
   name: KRUIZE_IMAGE_TAG
   required: true
   value: "190a6cc"
-- description: Kruize server host
-  name: KRUIZE_HOST
-  required: true
-  value: "ros-ocp-backend-kruize"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -1,0 +1,128 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: kruize
+objects:
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: kruize
+  spec:
+    envName: ${ENV_NAME}
+    deployments:
+    - name: kruize
+      replicas: ${{KRUIZE_REPLICA_COUNT}}
+      webServices:
+        private:
+          enabled: true
+      podSpec:
+        image: ${KRUIZE_IMAGE}:${KRUIZE_IMAGE_TAG}
+        command: ["sh"]
+        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && bash target/bin/Autotune"]
+        machinePool: ${MACHINE_POOL_OPTION}
+        resources:
+          requests:
+            cpu: ${KRUIZE_CPU_REQUEST}
+            memory: ${KRUIZE_MEMORY_REQUEST}
+          limits:
+            cpu: ${KRUIZE_CPU_LIMIT}
+            memory: ${KRUIZE_MEMORY_LIMIT}
+        env:
+          - name: AUTOTUNE_SERVER_PORT
+            value: ${KRUIZE_PORT}
+          - name: AUTH_TOKEN
+            value: ""
+          - name: LOGGING_LEVEL
+            value: "info"
+          - name: ROOT_LOGGING_LEVEL
+            value: "info"
+          - name: dbdriver
+            value: "jdbc:postgresql://"
+          - name: database_name
+            value: ${KRUIZE_DB_NAME}
+          - name: clustertype
+            value: "kubernetes"
+          - name: k8stype
+            value: "openshift"
+          - name: authtype
+            value: "openshift"
+          - name: monitoringagent
+            value: "prometheus"
+          - name: monitoringservice
+            value: "prometheus-k8s"
+          - name: monitoringendpoint
+            value: "prometheus-k8s"
+          - name: savetodb
+            value: "true"
+          - name: hibernate_dialect
+            value: "org.hibernate.dialect.PostgreSQLDialect"
+          - name: hibernate_driver
+            value: "org.postgresql.Driver"
+          - name: hibernate_c3p0minsize
+            value: "2"
+          - name: hibernate_c3p0maxsize
+            value: "5"
+          - name: hibernate_c3p0timeout
+            value: "300"
+          - name: hibernate_c3p0maxstatements
+            value: "50"
+          - name: hibernate_hbm2ddlauto
+            value: "update"
+          - name: hibernate_showsql
+            value: "false"
+          - name: hibernate_timezone
+            value: "UTC"
+          - name: SSL_CERT_DIR
+            value: ${SSL_CERT_DIR}
+    database:
+      name: kruize
+      version: 13
+    testing:
+      iqePlugin: ros-ocp
+
+parameters:
+- description : ClowdEnvironment name
+  name: ENV_NAME
+  required: true
+- description: Kruize database name
+  name: KRUIZE_DB_NAME
+  required: true
+- description: Kruize image name
+  name: KRUIZE_IMAGE
+  required: true
+  value: quay.io/cloudservices/autotune
+- description: Kruize image tag
+  name: KRUIZE_IMAGE_TAG
+  required: true
+  value: "190a6cc"
+- description: Kruize server host
+  name: KRUIZE_HOST
+  required: true
+  value: "ros-ocp-backend-kruize"
+- description: Kruize server port
+  name: KRUIZE_PORT
+  required: true
+  value: "10000"
+- description: Initial kruize cpu request.
+  displayName: KRUIZE CPU Request
+  name: KRUIZE_CPU_REQUEST
+  required: true
+  value: 500m
+- description: Initial amount of memory kruize container will request.
+  displayName: KRUIZE Memory Request
+  name: KRUIZE_MEMORY_REQUEST
+  required: true
+  value: 1Gi
+- description: Maximum amount of memory kruize container can use.
+  displayName: KRUIZE Memory Limit
+  name: KRUIZE_MEMORY_LIMIT
+  required: true
+  value: 1Gi
+- description: Replica count for kruize pod
+  name: KRUIZE_REPLICA_COUNT
+  value: "1"
+- name: MACHINE_POOL_OPTION
+  value: ''
+- name: SSL_CERT_DIR
+  value: '/etc/ssl/certs:/etc/pki/tls/certs:/system/etc/security/cacerts:/cdapp/certs'

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -115,6 +115,11 @@ parameters:
   name: KRUIZE_MEMORY_REQUEST
   required: true
   value: 1Gi
+- description: Maximum amount of CPU kruize container can use.
+  displayName: KRUIZE CPU Limit
+  name: KRUIZE_CPU_LIMIT
+  required: true
+  value: '1'
 - description: Maximum amount of memory kruize container can use.
   displayName: KRUIZE Memory Limit
   name: KRUIZE_MEMORY_LIMIT

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -88,6 +88,7 @@ parameters:
 - description: Kruize database name
   name: KRUIZE_DB_NAME
   required: true
+  value: "kruize"
 - description: Kruize image name
   name: KRUIZE_IMAGE
   required: true


### PR DESCRIPTION
### Changes
Splitting kruize deployment into a new ClowdApp

Steps to verify on EE:

### 1. Clone PR changes

### 2. Update local bonfire config as below.

Path: ```~/<user>/.config/bonfire/config.yaml```

```
# Bonfire deployment configuration

# Defines where to fetch the file that defines application configs
appsFile:
  host: gitlab
  repo: insights-platform/cicd-common
  path: bonfire_configs/ephemeral_apps.yaml

# (optional) define any apps locally. An app defined here with <name> will override config for app
# <name> in above fetched config.
apps:
- name: kruize
  components:
    - name: kruize
      host: github
      repo: RedHatInsights/ros-ocp-backend
      path: /kruize-clowdapp.yaml
```

### 3. Deploy updated ros-ocp-backend clowder changes

```
oc process --local -p ENV_NAME=env-<reserved EE namespace> -p IMAGE_TAG=pr-102-c890c67 -p RBAC_ENABLE=false -f ~/<path>/ros-ocp-backend/clowdapp.yaml | oc apply -n <reserved EE namespace> -f -
```

### 4. Deploy new kruize clowder changes

```
oc process --local -p ENV_NAME=env-<reserved EE namespace> -p KRUIZE_IMAGE_TAG=190a6cc -f ~/<path>/ros-ocp-backend/kruize-clowdapp.yaml | oc apply -n <reserved EE namespace> -f -
```

### 5. Generate test recommendation

```make archive-to-minio env=<reserved EE namespace>```

### 6. Update Makefile

Add query param ```?start_date=2023-04-01``` to Makefile L#121

### 7. Request recommendation from API

```make get-recommendations env=<reserved EE namespace>```

### Note:
Kruize hostname has changed and  it has its own database called ```kruize``` inside kruize-db pod, even in EE.

```
kruize-db-764c5dd5ff-8b4n5                                       1/1     Running   1 (43m ago)   43m
kruize-recommendations-6c847ffdb8-r575m                          1/1     Running   0             43m
puptoo-processor-67ff5fc6bb-ngjq4                                1/1     Running   0             48m
puptoo-redis-68c8b74bff-glqdg                                    1/1     Running   0             48m
rbac-db-784c5c7c68-85dkg                                         1/1     Running   1 (47m ago)   47m
rbac-redis-54c955d995-rvw24                                      1/1     Running   0             47m
rbac-service-688f9bc9c6-zv98z                                    2/2     Running   0             47m
ros-ocp-backend-api-84b77b9696-lwf9z                             2/2     Running   0             17m
ros-ocp-backend-db-5d4bc5bfcf-xbn8x                              1/1     Running   1 (47m ago)   47m
ros-ocp-backend-processor-7fdc86b9c4-mlsrk                       1/1     Running   0             24m
ros-ocp-backend-recommender-76f557f86b-tzn5t                     1/1     Running   0             24m

```