### PR TITLE
Fix pr_check job

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -5,7 +5,7 @@
 # --------------------------------------------
 export APP_NAME="ros"  # name of app-sre "application" folder this component lives in
 export COMPONENT_NAME="ros-ocp-backend"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
-export COMPONENTS="ros-ocp-backend"
+export COMPONENTS="kruize ros-ocp-backend"
 export IMAGE="quay.io/cloudservices/ros-ocp-backend"
 export DOCKERFILE="Dockerfile"
 


### PR DESCRIPTION
With the separation of the kruize DB, Kruize has became a separate component in ROS. So we should deploy kruize service in ephemeral environment with ros-ocp-backend. 