### PR TITLE
Changing SOURCES_API_PREFIX

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -158,7 +158,7 @@ func initConfig() {
 
 	}
 
-	viper.SetDefault("SOURCES_API_PREFIX", "/api/sources/v3.1")
+	viper.SetDefault("SOURCES_API_PREFIX", "/api/sources/v1.0")
 	viper.SetDefault("SERVICE_NAME", "rosocp")
 	viper.SetDefault("API_PORT", "8000")
 	viper.SetDefault("KRUIZE_WAIT_TIME", "30")


### PR DESCRIPTION
In local setup API v3.1 had worked but looking at the COST code - [here](https://github.com/project-koku/koku/blob/main/koku/sources/config.py#L26). API version should be `v1.0`