### PR TITLE
Enabling kafka autocommit setting

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -163,7 +163,7 @@ func initConfig() {
 	viper.SetDefault("API_PORT", "8000")
 	viper.SetDefault("KRUIZE_WAIT_TIME", "30")
 	viper.SetDefault("KAFKA_CONSUMER_GROUP_ID", "ros-ocp")
-	viper.SetDefault("KAFKA_AUTO_COMMIT", false)
+	viper.SetDefault("KAFKA_AUTO_COMMIT", true)
 	viper.SetDefault("LOG_LEVEL", "INFO")
 	viper.SetDefault("KRUIZE_HOST", "localhost")
 	viper.SetDefault("KRUIZE_PORT", "8080")


### PR DESCRIPTION
Enabling this setting to get the consumerlag in prometheus. 