### PR TITLE
Added index for workload_metrics

### DIFF
--- a/migrations/000010_create_worload_metrics_index.down.sql
+++ b/migrations/000010_create_worload_metrics_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_workload_metrics_workload_id_interval_end;

--- a/migrations/000010_create_worload_metrics_index.up.sql
+++ b/migrations/000010_create_worload_metrics_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_workload_metrics_workload_id_interval_end ON workload_metrics(workload_id, interval_end);


### PR DESCRIPTION
RDS is under heavy load due to this query -  https://github.com/RedHatInsights/ros-ocp-backend/blob/main/internal/model/workload_metrics.go#L39 
Adding index to improve the query performance. 

Before - it is doing Seq Scan on workload_metrics
```
                                                               QUERY PLAN                                                               
--------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.16..32.32 rows=1 width=1420) (actual time=0.266..0.267 rows=1 loops=1)
   ->  Seq Scan on workload_metrics  (cost=0.00..19.29 rows=5 width=1264) (actual time=0.091..0.198 rows=5 loops=1)
         Filter: (interval_end = '2023-09-24 00:15:00+00'::timestamp with time zone)
         Rows Removed by Filter: 98
   ->  Memoize  (cost=0.16..4.98 rows=1 width=156) (actual time=0.013..0.013 rows=0 loops=5)
         Cache Key: workload_metrics.workload_id
         Cache Mode: logical
         Hits: 2  Misses: 3  Evictions: 0  Overflows: 0  Memory Usage: 1kB
         ->  Index Scan using workloads_pkey on workloads  (cost=0.15..4.97 rows=1 width=156) (actual time=0.018..0.018 rows=0 loops=3)
               Index Cond: (id = workload_metrics.workload_id)
               Filter: (experiment_name = '3340851|111|222|Yuptoo-prod|replicaset|Yuptoo-app'::text)
               Rows Removed by Filter: 1
 Planning Time: 0.527 ms
 Execution Time: 0.419 ms
(14 rows)
----------
```

After - It is doing Index Scan using idx_workload_metrics_workload_id_interval_end on workload_metrics 

```
                                                         QUERY PLAN                                                                    
            
----------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=0.14..9.21 rows=1 width=1420) (actual time=0.029..0.030 rows=1 loops=1)
   ->  Seq Scan on workloads  (cost=0.00..1.04 rows=1 width=156) (actual time=0.012..0.012 rows=1 loops=1)
         Filter: (experiment_name = '3340851|111|222|Yuptoo-prod|replicaset|Yuptoo-app'::text)
         Rows Removed by Filter: 2
   ->  Index Scan using idx_workload_metrics_workload_id_interval_end on workload_metrics  (cost=0.14..8.16 rows=1 width=1264) (actual time=0.015..0.016 rows
=1 loops=1)
         Index Cond: ((workload_id = workloads.id) AND (interval_end = '2023-09-24 01:30:00+00'::timestamp with time zone))
 Planning Time: 0.473 ms
 Execution Time: 0.078 ms
(8 rows)
```