### PR TITLE
Fixes: #RHIROS-1365 - Removed unnecessary workload_metrics check

### DIFF
--- a/internal/model/workload_metrics.go
+++ b/internal/model/workload_metrics.go
@@ -22,7 +22,7 @@ func (w *WorkloadMetrics) CreateWorkloadMetrics() error {
 	db := database.GetDB()
 	result := db.Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "workload_id"}, {Name: "container_name"}, {Name: "interval_start"}, {Name: "interval_end"}},
-		DoUpdates: clause.AssignmentColumns([]string{"usage_metrics"}),
+		DoNothing: true,
 	}).Create(w)
 
 	if result.Error != nil {
@@ -31,11 +31,4 @@ func (w *WorkloadMetrics) CreateWorkloadMetrics() error {
 	}
 
 	return nil
-}
-
-func GetWorkloadMetricsForTimestamp(experiment_name string, interval_end time.Time) (WorkloadMetrics, error) {
-	db := database.GetDB()
-	var workload_metrics WorkloadMetrics
-	err := db.Table("workload_metrics").Joins("JOIN workloads ON workloads.id = workload_metrics.workload_id AND workloads.experiment_name = ? AND workload_metrics.interval_end = ?", experiment_name, interval_end).Scan(&workload_metrics).Error
-	return workload_metrics, err
 }

--- a/internal/services/report_processor.go
+++ b/internal/services/report_processor.go
@@ -146,14 +146,6 @@ func ProcessReport(msg *kafka.Message) {
 						continue
 					}
 
-					if workload_metrics, err := model.GetWorkloadMetricsForTimestamp(experiment_name, interval_end_time); err != nil {
-						log.Errorf("Error while checking for workload_metrics record: %s", err)
-						continue
-					} else if !reflect.ValueOf(workload_metrics).IsZero() {
-						log.Debugf("workload_metrics table already has data for interval_end time: %v.", interval_end_time)
-						continue
-					}
-
 					for _, container := range data.Kubernetes_objects[0].Containers {
 						container_usage_metrics, err := json.Marshal(container.Metrics)
 						if err != nil {


### PR DESCRIPTION
`workload_metrics` check on line 149 was initially written to optimize the codebase, that is to avoid the `for loop` on line 157 in case if duplicate report is uploaded. But in production it is very rare that duplicate report will arrive because cost operator will never do that. 
This check is hampering the DB performance hence removing it.

![Screenshot 2023-09-25 at 9 45 07 PM](https://github.com/RedHatInsights/ros-ocp-backend/assets/31805557/bdd62f57-a366-4de5-9e3f-a15449f3a5bc)
