### PR TITLE
[ROS-OCP] Make API specifications available under Insights API documentation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -12,7 +12,13 @@
   "paths": {
     "/recommendations/openshift": {
       "get": {
+        "tags": [ "Optimizations" ],
         "summary": "Get all recommendations",
+        "description": "This feature is in limited preview for select customers",
+        "externalDocs": {
+          "description": "Please refer to this blog post if you want to be included in the preview",
+          "url": "https://www.redhat.com/en/blog/red-hat-insights-brings-resource-optimization-red-hat-openshift"
+        },
         "operationId": "getRecommendationList",
         "parameters": [
           {
@@ -147,6 +153,12 @@
     },
     "/recommendations/openshift/{recommendation-id}": {
       "get": {
+        "tags": [ "Optimizations" ],
+        "description": "This feature is in limited preview for select customers",
+        "externalDocs": {
+          "description": "Please refer to this blog post if you want to be included in the preview",
+          "url": "https://www.redhat.com/en/blog/red-hat-insights-brings-resource-optimization-red-hat-openshift"
+        },
         "operationId": "getRecommendationById",
         "parameters": [
           {


### PR DESCRIPTION
This PR includes changes on **ROS OCP** side for ``openapi.json`` file in which I have added for **paths** 
``` 
"/recommendations/openshift": {
   "get": {
       "tags": [ "Optimizations" ],
```
This change is required to use **ROS OCP** ``openapi.json`` as external **$ref** to display endpoints in **Cost-mgmt OpenAPI spec file** as per attached screenshots - 

![image](https://github.com/RedHatInsights/ros-ocp-backend/assets/53873549/251a9e4b-b037-4da4-aec9-8c116015f9bd)

For **$ref** link, it will directly point to **ROS-OCP openapi.json** raw file.

@chambridge As **ROS-OCP** service is under prod/preview mode, is there a way we can hide our endpoints when **Cost-mgmt** is not seen in preview mode?
