### PR TITLE
Ref-RHIROS-1292 Check if ROS-OCP openapi.json can ref Cost-Mgmt APIs in stage

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -196,6 +196,12 @@
           }
         }
       }
+    },
+    "/status/": {
+      "$ref": "https://raw.githubusercontent.com/project-koku/koku/main/docs/specs/openapi.json#/paths/~1status~1"
+    },
+    "/forecasts/aws/costs/": {
+      "$ref": "https://raw.githubusercontent.com/project-koku/koku/main/docs/specs/openapi.json#/paths/~1forecasts~1aws~1costs~1"
     }
   },
   "components": {


### PR DESCRIPTION
To check if **ROS-OCP** OpenAPI spec file can reference **Cost Mgmt** APIs in stage.

Added ref to `/stage/` and `/forecasts/aws/costs/` **Cost-Mgmt** API endpoints

Ref ROS-OCP side PR - https://github.com/RedHatInsights/ros-ocp-backend/pull/133

Ref Cost Mgmt PR - https://github.com/project-koku/koku/pull/4728 