### PR TITLE
RHIROS-1408 Add PR creation template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,41 @@
+## PR Title :boom:
+
+Please title this PR with a summary of the change, along with the JIRA card number.
+
+Suggested formats: 
+
+1. Fixes/Refs #RHIROS-XXX - Title
+2. RHIROS-XXX Title
+3. RHINENG-XXX Title 
+
+Feel free to remove this section from PR description once done.
+
+## Why do we need this change? :thought_balloon:
+
+Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!
+
+## Documentation update? :memo:
+
+- [ ] Yes
+- [ ] No
+
+## Security Checklist :lock:
+
+Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)
+
+## :guardsman: Checklist :dart:
+
+- [ ] Does this change depend on specific version of Kruize
+  - If yes what is the version no:
+  - [ ] Is that image available in production or needs deployment?
+- [ ] Bugfix
+- [ ] New Feature
+- [ ] Refactor
+- [ ] Unittests Added
+- [ ] DRY code
+- [ ] Dependency Added
+- [ ] DB Migration Added
+
+## Additional :mega:
+
+Feel free to add any other relevant details such as __links, notes, screenshots__, here.


### PR DESCRIPTION
Similar to ROS for RHEL repository, added one for ROS OCP too.

Refer - https://github.com/RedHatInsights/ros-backend/blob/main/.github/pull_request_template.md