### PR TITLE
Adjusting JAVA settings for 80% MaxRAMPercentage.

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -29,6 +29,8 @@ objects:
             cpu: ${KRUIZE_CPU_LIMIT}
             memory: ${KRUIZE_MEMORY_LIMIT}
         env:
+          - name: JAVA_TOOL_OPTIONS
+            value: "-XX:MaxRAMPercentage=80"
           - name: CLOWDER_ENABLED
             value: ${CLOWDER_ENABLED}
           - name: AUTOTUNE_SERVER_PORT


### PR DESCRIPTION
Setting -XX:MaxRAMPercentage=80 in JAVA options adjusts the maximum RAM allocation to 80%. This means that when the Java Virtual Machine (JVM) runs, it will limit its memory usage to 80% of the available system RAM. This setting can be beneficial for resource management, preventing excessive memory usage and potential performance issues. It provides a balance between allowing Java applications to utilize a substantial amount of RAM while ensuring there is still sufficient memory for other system processes and applications. Adjusting this parameter can contribute to a more efficient and stable performance of Java applications.