### PR TITLE
Don't silent curl commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ upload-msg-to-rosocp:
 get-recommendations:
 ifdef env
 	$(eval APIPOD=$(shell oc get pods -o custom-columns=POD:.metadata.name --no-headers -n ${env} | grep ros-ocp-backend-api))
-	oc exec ${APIPOD} -c ros-ocp-backend-api -n ${env} -- /bin/bash -c 'curl -s -H "X-Rh-Identity: ${b64_identity}" -H "x-rh-request_id: testtesttest" http://localhost:8000/api/cost-management/v1/recommendations/openshift?start_date=${start_date}' | python -m json.tool
+	oc exec ${APIPOD} -c ros-ocp-backend-api -n ${env} -- /bin/bash -c 'curl -v -H "X-Rh-Identity: ${b64_identity}" -H "x-rh-request_id: testtesttest" http://localhost:8000/api/cost-management/v1/recommendations/openshift?start_date=${start_date}' | python -m json.tool
 else
-	curl -s -H "x-rh-identity: ${b64_identity}" \
+	curl -v -H "x-rh-identity: ${b64_identity}" \
 		 -H "x-rh-request_id: testtesttest" \
 		 http://localhost:8000/api/cost-management/v1/recommendations/openshift?start_date=${start_date} | python -m json.tool
 endif


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

If we don't have api container started then curl fails, which is expected. However the `-s` usage with curl does not show connection issue as it silents the error. The curl commands should not be silent as the errors are confusing,

curl -s
~~~
$ make get-recommendations 
curl -s -H "x-rh-identity: eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjMzNDA4NTEiLCAidHlwZSI6ICJTeXN0ZW0iLCAiYXV0aF90eXBlIjogImNlcnQtYXV0aCIsICJzeXN0ZW0iOiB7ImNuIjogIjFiMzZiMjBmLTdmYTAtNDQ1NC1hNmQyLTAwODI5NGUwNjM3OCIsICJjZXJ0X3R5cGUiOiAic3lzdGVtIn0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjMzNDA4NTEiLCAiYXV0aF90aW1lIjogNjMwMH19fQo=" \
	 -H "x-rh-request_id: testtesttest" \
	 http://localhost:8000/api/cost-management/v1/recommendations/openshift?start_date=1970-01-01 | python -m json.tool
Expecting value: line 1 column 1 (char 0)
make: *** [Makefile:119: get-recommendations] Error 1
~~~

curl -v
~~~
$ make get-recommendations 
curl -v -H "x-rh-identity: eyJpZGVudGl0eSI6IHsib3JnX2lkIjogIjMzNDA4NTEiLCAidHlwZSI6ICJTeXN0ZW0iLCAiYXV0aF90eXBlIjogImNlcnQtYXV0aCIsICJzeXN0ZW0iOiB7ImNuIjogIjFiMzZiMjBmLTdmYTAtNDQ1NC1hNmQyLTAwODI5NGUwNjM3OCIsICJjZXJ0X3R5cGUiOiAic3lzdGVtIn0sICJpbnRlcm5hbCI6IHsib3JnX2lkIjogIjMzNDA4NTEiLCAiYXV0aF90aW1lIjogNjMwMH19fQo=" \
	 -H "x-rh-request_id: testtesttest" \
	 http://localhost:8000/api/cost-management/v1/recommendations/openshift?start_date=1970-01-01 | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0*   Trying 127.0.0.1:8000...
* connect to 127.0.0.1 port 8000 failed: Connection refused
*   Trying [::1]:8000...
* connect to ::1 port 8000 failed: Connection refused
* Failed to connect to localhost port 8000 after 0 ms: Couldn't connect to server
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
* Closing connection 0
curl: (7) Failed to connect to localhost port 8000 after 0 ms: Couldn't connect to server
Expecting value: line 1 column 1 (char 0)
make: *** [Makefile:119: get-recommendations] Error 1
~~~

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.