### PR TITLE
Allow mounting volumes when selinux is enforcing mode

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -56,7 +56,7 @@ services:
   kruize-autotune:
     image: quay.io/cloudservices/autotune:6c23945
     volumes:
-      - ./cdappconfig.json:/tmp/cdappconfig.json
+      - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:
       - 8080:8080
     environment:
@@ -86,7 +86,7 @@ services:
   nginx:
     image: nginx
     volumes:
-      - ./samples:/usr/share/nginx/html
+      - ./samples:/usr/share/nginx/html:Z
     ports:
       - 8888:80
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

When Laptop/Host system has selinux in enforcing mode containers fail to read the files with permission errors,
~~~
type=AVC msg=audit(1704292413.722:14533): avc:  denied  { read } for  pid=194948 comm="java" name="cdappconfig.json" dev="nvme0n1p3" ino=853138065 scontext=system_u:system_r:container_t:s0:c868,c911 tcontext=unconfined_u:object_r:user_home_t:s0 tclass=file permissive=0

nginx_1                | 2024/01/03 14:49:59 [error] 29#29: *1 open() "/usr/share/nginx/html/ros-ocp-usage.csv" failed (13: Permission denied), client: 172.26.0.1, server: localhost, request: "GET /ros-ocp-usage.csv HTTP/1.1", host: "localhost:8888"
~~~


## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.