### PR TITLE
Fixes #RHINENG-2879 - Pin Golang version for go-toolset

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM registry.redhat.io/ubi8/go-toolset:latest as builder
+FROM registry.redhat.io/ubi8/go-toolset:1.20 as builder
 WORKDIR /go/src/app
 COPY . .
 USER 0
 RUN go get -d ./... && \
-    go build -o rosocp rosocp.go
+    go build -o rosocp rosocp.go && \
+    echo "$(go version)" > go_version_details
 
 FROM registry.redhat.io/ubi8/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /go/src/app/rosocp ./rosocp
+COPY --from=builder /go/src/app/go_version_details ./go_version_details
 COPY migrations ./migrations
 COPY openapi.json ./openapi.json
 COPY resource_optimization_openshift.json ./resource_optimization_openshift.json

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhatinsights/ros-ocp-backend
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.38.51


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The latest tag of go-toolset keeps on updating as per the 1.y versions of Go. Considering the go packages being used in repository are tested for Golang 1.19.z this change specifically pins it in Dockerfile to be surefooted for production releases.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.