### PR TITLE
[QE] adding perf block

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,6 +27,15 @@ source $CICD_ROOT/deploy_ephemeral_env.sh
 echo "sleeping for 5 min"
 sleep 5m
 
+# Creating perf profile
+echo "Starting to create perf profile"
+service="kruize-recommendations"
+oc expose svc/${service} -n ${NAMESPACE}
+SERVER_IP=($(oc status --namespace=${NAMESPACE} | grep ${service} | grep port | cut -d " " -f1 | cut -d "/" -f3))
+echo "IP = $SERVER_IP"
+KRUIZE_URL="http://${SERVER_IP}"
+curl -s -H 'Accept: application/json' ${KRUIZE_URL}/createPerformanceProfile -d @./resource_optimization_openshift.json 
+
 # Run iqe-ros-ocp smoke tests with ClowdJobInvocation
 export COMPONENT_NAME="ros-ocp-backend"
 source $CICD_ROOT/cji_smoke_test.sh


### PR DESCRIPTION
## PR Title :boom:

RHINENG-7040 - Adding perf block before executing tests 


## Why do we need this change? :thought_balloon:

Currently we are facing intermittent issues with pr checks due to performaance profile getting deleted as pods restart.
So this is for testing
## Documentation update? :memo:

- [ ] Yes
-  No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.