### PR TITLE
Fixes #RHINENG-7893 - accept and serve boxplots

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -199,7 +199,7 @@ func truncateComponentUnits(recommendationJSON map[string]interface{}) map[strin
 		Truncates CPU units(cores) to three decimal places
 		Truncates Memory units(Mi) to two decimal places
 		Hack: Truncates duration_in_hours to one decimal places
-		To Do: Once Kruize returns identical values for duration_in_hours
+		TODO: Once Kruize returns identical values for duration_in_hours
 		the ros-ocp should stop truncating the duration_in_hours
 	*/
 

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -198,7 +198,9 @@ func truncateComponentUnits(recommendationJSON map[string]interface{}) map[strin
 	/*
 		Truncates CPU units(cores) to three decimal places
 		Truncates Memory units(Mi) to two decimal places
-		Truncates duration_in_hours to one decimal places
+		Hack: Truncates duration_in_hours to one decimal places
+		To Do: Once Kruize returns identical values for duration_in_hours
+		the ros-ocp should stop truncating the duration_in_hours
 	*/
 
 	hasMoreThanThreeDecimals := func(value float64) bool {

--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -78,8 +78,8 @@ type RecommendationTerm struct {
 }
 
 type Plot struct {
-	DataPoints int                  `json:"datapoints,omitempty"`
-	PlotsData  map[string]PlotsData `json:"plots_data,omitempty"`
+	DataPoints int                  `json:"datapoints"`
+	PlotsData  map[string]PlotsData `json:"plots_data"`
 }
 
 type PlotsData struct {
@@ -211,7 +211,7 @@ func make_container_data(c map[string]interface{}) container {
 		// Check if "sum" key exists in map
 		if sum_field, ok := metricFields["sum"]; ok {
 			if metricFields["format"] == "Mi" {
-				convertMemoryFields(sum_field, c)
+				convertMemoryField(sum_field, c)
 			}
 			// Assign the sum value returned
 			sum = AssertAndConvertToString(c[sum_field])
@@ -223,7 +223,7 @@ func make_container_data(c map[string]interface{}) container {
 		// Check if "avg" key exists in map
 		if avg_field, ok := metricFields["avg"]; ok {
 			if metricFields["format"] == "Mi" {
-				convertMemoryFields(avg_field, c)
+				convertMemoryField(avg_field, c)
 			}
 			// Assign the avg value returned
 			avg = AssertAndConvertToString(c[avg_field])
@@ -235,7 +235,7 @@ func make_container_data(c map[string]interface{}) container {
 		// Check if "min" key exists in map
 		if min_field, ok := metricFields["min"]; ok {
 			if metricFields["format"] == "Mi" {
-				convertMemoryFields(min_field, c)
+				convertMemoryField(min_field, c)
 			}
 			// Assign the min value returned
 			min = AssertAndConvertToString(c[min_field])
@@ -247,7 +247,7 @@ func make_container_data(c map[string]interface{}) container {
 		// Check if "max" key exists in map
 		if max_field, ok := metricFields["max"]; ok {
 			if metricFields["format"] == "Mi" {
-				convertMemoryFields(max_field, c)
+				convertMemoryField(max_field, c)
 			}
 			// Assign the max value returned
 			max = AssertAndConvertToString(c[max_field])
@@ -291,14 +291,14 @@ func make_container_data(c map[string]interface{}) container {
 	return container_data
 }
 
-func convertMemoryFields(field string, c map[string]interface{}) {
+func convertMemoryField(field string, c map[string]interface{}) {
 	log := logging.GetLogger()
 	var memoryInMi float64
 	memField, ok := c[field].(float64)
 	if ok {
 		memoryInMi = memField / 1024 / 1024
 	} else {
-		log.Warn("Failed to convert field: ", field)
+		log.Error("Failed to convert field: ", field)
 		return
 	}
 	c[field] = memoryInMi

--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -79,21 +79,21 @@ type RecommendationTerm struct {
 
 type Plot struct {
 	DataPoints int                  `json:"datapoints"`
-	PlotsData  map[string]PlotsData `json:"plots_data"`
+	PlotsData  map[string]PlotsData `json:"plots_data,omitempty"`
 }
 
 type PlotsData struct {
-	CpuUsage    BoxPlotDetails `json:"cpuUsage,omitempty"`
-	MemoryUsage BoxPlotDetails `json:"memoryUsage,omitempty"`
+	CpuUsage    *BoxPlotDetails `json:"cpuUsage,omitempty"`
+	MemoryUsage *BoxPlotDetails `json:"memoryUsage,omitempty"`
 }
 
 type BoxPlotDetails struct {
-	Min    float64 `json:"min"`
-	Q1     float64 `json:"q1"`
-	Median float64 `json:"median"`
-	Q3     float64 `json:"q3"`
-	Max    float64 `json:"max"`
-	Format string  `json:"format"`
+	Min    float64 `json:"min,omitempty"`
+	Q1     float64 `json:"q1,omitempty"`
+	Median float64 `json:"median,omitempty"`
+	Q3     float64 `json:"q3,omitempty"`
+	Max    float64 `json:"max,omitempty"`
+	Format string  `json:"format,omitempty"`
 }
 
 type Term struct {

--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -74,11 +74,11 @@ type RecommendationTerm struct {
 		Cost        RecommendationEngineObject `json:"cost,omitempty"`
 		Performance RecommendationEngineObject `json:"performance,omitempty"`
 	} `json:"recommendation_engines,omitempty"`
-	Plots Plot `json:"plots,omitempty"`
+	Plots *Plot `json:"plots,omitempty"`
 }
 
 type Plot struct {
-	DataPoints int                  `json:"datapoints"`
+	DataPoints int                  `json:"datapoints,omitempty"`
 	PlotsData  map[string]PlotsData `json:"plots_data,omitempty"`
 }
 

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -102,7 +102,7 @@ objects:
           - name: logging_cloudwatch_logLevel
             value: ${KRUIZE_CW_LOGGING_LEVEL}
           - name: plots
-            value: "true"
+            value: ${PLOTS_DATA}
     jobs:
       - name: delete-kruize-partitions
         schedule: ${KRUIZE_PARTITION_INTERVAL}
@@ -278,3 +278,5 @@ parameters:
   value: "kruize-recommendations"
 - name: KRUIZE_CW_LOGGING_LEVEL
   value: "INFO"
+- name: PLOTS_DATA
+  value: "false"

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -101,6 +101,8 @@ objects:
             value: ${KRUIZE_CW_LOG_STREAM}
           - name: logging_cloudwatch_logLevel
             value: ${KRUIZE_CW_LOGGING_LEVEL}
+          - name: plots
+            value: "true"
     jobs:
       - name: delete-kruize-partitions
         schedule: ${KRUIZE_PARTITION_INTERVAL}

--- a/openapi.json
+++ b/openapi.json
@@ -387,7 +387,8 @@
         "properties": {
           "duration_in_hours": {
             "type": "number",
-            "example": 360
+            "format": "float",
+            "example": 360.2
           },
           "monitoring_start_time": {
             "type": "string",
@@ -415,7 +416,8 @@
         "properties": {
           "duration_in_hours": {
             "type": "number",
-            "example": 168
+            "format": "float",
+            "example": 168.1
           },
           "monitoring_start_time": {
             "type": "string",
@@ -443,6 +445,7 @@
         "properties": {
           "duration_in_hours": {
             "type": "number",
+            "format": "float",
             "example": 24.7
           },
           "monitoring_start_time": {
@@ -1014,7 +1017,8 @@
                       },
                       "duration_in_hours": {
                         "type": "number",
-                        "example": 361
+                        "format": "float",
+                        "example": 361.2
                       },
                       "monitoring_end_time": {
                         "type": "string",
@@ -1248,7 +1252,8 @@
                       },
                       "duration_in_hours": {
                         "type": "number",
-                        "example": 169
+                        "format": "float",
+                        "example": 169.1
                       },
                       "monitoring_end_time": {
                         "type": "string",
@@ -1482,7 +1487,8 @@
                       },
                       "duration_in_hours": {
                         "type": "number",
-                        "example": 25
+                        "format": "float",
+                        "example": 25.1
                       },
                       "monitoring_end_time": {
                         "type": "string",
@@ -1562,17 +1568,7 @@
               }
             }
           },
-          "2023-04-02T00:00:00Z":{
-            "type": "object",
-            "properties":{
-              "cpuUsage":{
-                "$ref": "#/components/schemas/cpuUsage"
-              },
-              "memoryUsage":{
-                "$ref":"#/components/schemas/memoryUsage"
-              }
-            }
-          }
+          "2023-04-02T00:00:00Z":{}
         }
       },
       "cpuUsage": {

--- a/openapi.json
+++ b/openapi.json
@@ -1568,7 +1568,10 @@
               }
             }
           },
-          "2023-04-02T00:00:00Z":{}
+          "2023-04-02T00:00:00Z":{
+            "type": "object",
+            "additionalProperties": false
+          }
         }
       },
       "cpuUsage": {

--- a/openapi.json
+++ b/openapi.json
@@ -404,6 +404,9 @@
                 "$ref": "#/components/schemas/PerformanceRecommendation"
               }
             }
+          },
+          "plots":{
+            "$ref": "#/components/schemas/PlotsData"
           }
         }
       },
@@ -429,6 +432,9 @@
                 "$ref": "#/components/schemas/PerformanceRecommendation"
               }
             }
+          },
+          "plots":{
+            "$ref":"#/components/schemas/PlotsData"
           }
         }
       },
@@ -454,6 +460,9 @@
                 "$ref": "#/components/schemas/PerformanceRecommendation"
               }
             }
+          },
+          "plots":{
+            "$ref": "#/components/schemas/PlotsData"
           }
         }
       },
@@ -485,11 +494,11 @@
                     "properties": {
                       "amount": {
                         "type": "number",
-                        "example": 6.7
+                        "example": 6700
                       },
                       "format": {
                         "type": "string",
-                        "example": "Gi"
+                        "example": "Mi"
                       }
                     }
                   }
@@ -558,11 +567,11 @@
                     "properties": {
                       "amount": {
                         "type": "number",
-                        "example": 1.7
+                        "example": 1700
                       },
                       "format": {
                         "type": "string",
-                        "example": "Gi"
+                        "example": "Mi"
                       }
                     }
                   }
@@ -622,7 +631,8 @@
                       },
                       "format": {
                         "type": "string",
-                        "example": "millicores"
+                        "example": null,
+                        "nullable": true
                       }
                     }
                   },
@@ -663,11 +673,11 @@
                     "properties": {
                       "amount": {
                         "type": "number",
-                        "example": 6
+                        "example": 6000
                       },
                       "format": {
                         "type": "string",
-                        "example": "Gi"
+                        "example": "Mi"
                       }
                     }
                   }
@@ -736,11 +746,11 @@
                     "properties": {
                       "amount": {
                         "type": "number",
-                        "example": 1
+                        "example": 1056
                       },
                       "format": {
                         "type": "string",
-                        "example": "Gi"
+                        "example": "Mi"
                       }
                     }
                   }
@@ -982,7 +992,7 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 3.995
+                                    "example": 3000
                                   },
                                   "format": {
                                     "type": "string",
@@ -1078,11 +1088,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 5
+                                    "example": 5000
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1105,7 +1115,8 @@
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "millicores"
+                                    "example": null,
+                                    "nullable": true
                                   }
                                 }
                               },
@@ -1146,11 +1157,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 6
+                                    "example": 6000
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1215,11 +1226,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 1
+                                    "example": 1000
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1279,11 +1290,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 5
+                                    "example": 550
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1348,11 +1359,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 6.7
+                                    "example": 6700
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1417,11 +1428,11 @@
                                 "properties": {
                                   "amount": {
                                     "type": "number",
-                                    "example": 1.7
+                                    "example": 1500
                                   },
                                   "format": {
                                     "type": "string",
-                                    "example": "Gi"
+                                    "example": "Mi"
                                   }
                                 }
                               }
@@ -1502,6 +1513,126 @@
             "example": "deploymentconfig"
           }
         }
+      },
+      "PlotsData":{
+        "type": "object",
+        "properties":{
+          "datapoints":{
+            "type": "integer",
+            "example": 4
+          },
+        "plots_data":{
+          "$ref": "#/components/schemas/PlotDetails"
+          }
+        }
+      },
+      "PlotDetails": {
+        "type": "object",
+        "properties":{
+          "2023-04-01T06:00:00Z":{
+            "type": "object",
+            "properties":{
+              "cpuUsage":{
+                "$ref": "#/components/schemas/cpuUsage"
+              },
+              "memoryUsage":{
+                "$ref":"#/components/schemas/memoryUsage"
+              }
+            }
+          },
+          "2023-04-01T12:00:00Z":{
+            "type": "object",
+            "properties":{
+              "cpuUsage":{
+                "$ref": "#/components/schemas/cpuUsage"
+              },
+              "memoryUsage":{
+                "$ref":"#/components/schemas/memoryUsage"
+              }
+            }
+          },
+          "2023-04-01T18:00:00Z":{
+            "type": "object",
+            "properties":{
+              "cpuUsage":{
+                "$ref": "#/components/schemas/cpuUsage"
+              },
+              "memoryUsage":{
+                "$ref":"#/components/schemas/memoryUsage"
+              }
+            }
+          },
+          "2023-04-02T00:00:00Z":{
+            "type": "object",
+            "properties":{
+              "cpuUsage":{
+                "$ref": "#/components/schemas/cpuUsage"
+              },
+              "memoryUsage":{
+                "$ref":"#/components/schemas/memoryUsage"
+              }
+            }
+          }
+        }
+      },
+      "cpuUsage": {
+        "type": "object",
+        "properties":{
+          "format":{
+            "type": "string",
+            "example": null,
+            "nullable": true
+          },
+          "max":{
+            "$ref": "#/components/schemas/cpuUsageFloatComponent"
+          },
+          "median":{
+            "$ref": "#/components/schemas/cpuUsageFloatComponent"
+          },
+          "min":{
+            "$ref": "#/components/schemas/cpuUsageFloatComponent"
+          },
+          "q1":{
+            "$ref": "#/components/schemas/cpuUsageFloatComponent"
+          },
+          "q3":{
+            "$ref": "#/components/schemas/cpuUsageFloatComponent"
+          }
+        }
+      },
+      "memoryUsage":{
+        "type": "object",
+        "properties":{
+          "format":{
+            "type": "string",
+            "example": "Mi"
+          },
+          "max":{
+            "$ref": "#/components/schemas/memoryUsageFloatComponent"
+          },
+          "median":{
+            "$ref": "#/components/schemas/memoryUsageFloatComponent"
+          },
+          "min":{
+            "$ref": "#/components/schemas/memoryUsageFloatComponent"
+          },
+          "q1":{
+            "$ref": "#/components/schemas/memoryUsageFloatComponent"
+          },
+          "q3":{
+            "$ref": "#/components/schemas/memoryUsageFloatComponent"
+          }
+        }
+      },
+      "cpuUsageFloatComponent":{
+        "type": "number",
+        "example": 0.05,
+        "format": "float"
+      },
+      "memoryUsageFloatComponent":{
+        "type": "number",
+        "example": 238.2,
+        "format": "float"
       }
     }
   }

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/cloudservices/autotune:6a63d31
+    image: quay.io/cloudservices/autotune:1672d29
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:
@@ -92,6 +92,7 @@ services:
       - hibernate_hbm2ddlauto=none
       - hibernate_showsql=false
       - hibernate_timezone=UTC
+      - plots=true
     depends_on:
         - db-kruize
   nginx:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The Kruize added feature to include the boxplot data in response. The ROS should accept the new boxplot data, save it and serve it finally to be consumed by UI/API.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - Kruize version is undecided as of now
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.