### PR TITLE
Tuning kafka consumer config

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -39,6 +39,8 @@ func StartConsumer(kafka_topic string, handler func(msg *kafka.Message, consumer
 			"enable.auto.commit":       auto_commit,
 			"go.logs.channel.enable":   true,
 			"allow.auto.create.topics": true,
+			"session.timeout.ms":       120000,
+			"heartbeat.interval.ms":    30000,
 		}
 
 		// As per librdkafka doc - https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md?plain=1#L73


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

There are kafka metrics gaps observed in grafana. Possible cause for this is rebalancing which occurs in kafka consumer groups. 

Below are the reference link for the config params `session.timeout.ms` and `heartbeat.interval.ms`.
https://kafka.apache.org/34/documentation.html#consumerconfigs_heartbeat.interval.ms
https://kafka.apache.org/34/documentation.html#consumerconfigs_session.timeout.ms

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added
