### PR TITLE
Use different Prometheus ports for every server locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,15 +60,15 @@ db-migrate:
 
 .PHONY: run-processor
 run-processor:
-	go run rosocp.go start processor
+	PROMETHEUS_PORT=5005 go run rosocp.go start processor
 
 .PHONY: run-recommender
 run-recommendation-poller:
-	go run rosocp.go start recommendation-poller
+	PROMETHEUS_PORT=5006 go run rosocp.go start recommendation-poller
 
 .PHONY: run-api-server
 run-api-server:
-	go run rosocp.go start api
+	PROMETHEUS_PORT=5007 go run rosocp.go start api
 
 .PHONY: build
 build:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The report-processor, recommendation-poller and api-server starts prometheus server, however the port for prometheus is hardcoded 5005 in the config. This change ties different PROMETHEUS_PORT for cmds in Makefile and then viper's AutomaticEnv() and GetString() is used to consume it.

With this change one can run all of the report-processor, recommendation-poller and api-server at a time without stopping any of them.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.