### PR TITLE
Upgrade kruize image to 20.02

### DIFF
--- a/internal/types/kruizePayload/updateResult.go
+++ b/internal/types/kruizePayload/updateResult.go
@@ -51,7 +51,7 @@ func GetUpdateResultPayload(experiment_name string, containers []map[string]inte
 			container_array = append(container_array, make_container_data(c))
 		}
 		payload = append(payload, UpdateResult{
-			Version:             "3.0",
+			Version:             "1.0",
 			Experiment_name:     experiment_name,
 			Interval_start_time: data["interval_start"],
 			Interval_end_time:   data["interval_end"],

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -159,7 +159,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "c84bd63"
+  value: "6a63d31"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/cloudservices/autotune:c84bd63
+    image: quay.io/cloudservices/autotune:6a63d31
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## :guardsman: Checklist :dart:

- [x] Does this change depend on specific version of Kruize
  - If yes what is the version no: 20.02
  - [x] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.