### PR TITLE
Fixes #RHINENG-7907 - use monitoring_end_time with start_date

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"testing"
+	"github.com/labstack/echo/v4"
+)
+
+func TestMapQueryParameters(t *testing.T) {
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	type tests struct {
+		name     string
+		qinputs  map[string]string
+		qoutputs map[string][]string
+		errmsg   string
+	}
+
+	var all_tests = []tests{
+		{
+			name:    "When start date and end date are provided",
+			qinputs: map[string]string{"start_date": "2023-03-23", "end_date": "2023-03-24"},
+			qoutputs: map[string][]string{
+				"DATE(recommendation_sets.monitoring_end_time) <= ?": {"2023-03-24"},
+				"DATE(recommendation_sets.monitoring_end_time) >= ?": {"2023-03-23"},
+			},
+			errmsg: `The recommendation_sets.monitoring_end_time should be less than or equal to end date!
+				The recommendation_sets.monitoring_end_time should be greater than or equal to start date!`,
+		},
+	}
+
+	for _, tt := range all_tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.qinputs {
+				c.QueryParams().Add(k, v)
+			}
+			result, _ := MapQueryParameters(c)
+			if reflect.DeepEqual(result, tt.qoutputs) != true {
+				t.Errorf(tt.errmsg)
+			}
+			for k := range c.QueryParams() {
+				delete(c.QueryParams(), k)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

On first of the month api returns nothing even though recommendations are stored. This is because monitoring_start_time for that recommendation is older than 1st of the current month. To fix this the filter has been changed to depend on monitoring_end_time. This does mean if we receive data partially between 28,29,30 or 31 to 1st then we show the recommendation if its there in OCP database.

With this I have also updated the logic to show error upon invalid/bad start_data and end_date instead of just logging error in service. This does mean if invalid date is provided we don't try to query with that to database, so fewer queries when we know param(s) are bad!
 
## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.