### PR TITLE
Fixes #RHINENG-9204 - adding new step in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN go get -d ./... && \
 
 FROM registry.redhat.io/ubi8/ubi-minimal:latest
 WORKDIR /
+RUN microdnf -y update
 COPY --from=builder /go/src/app/rosocp ./rosocp
 COPY --from=builder /go/src/app/go_version_details ./go_version_details
 COPY migrations ./migrations


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:
To get latest packages. 

WIth the current Dockerfile our base image is auto updated but it may happen that some package are updated in repo after creation of the base image like below. 
```
# podman image inspect quay.io/cloudservices/ros-ocp-backend:971c198  | grep "\"version\|\"release"   
                    "release": "1161",
                    "version": "8.9"
               "release": "1161",
               "version": "8.9"
```
We have the latest base image but as you can see below one package update was still available. 
```
# podman run --user root -it --rm  quay.io/cloudservices/ros-ocp-backend:971c198 bash 
WARNING: image platform (linux/amd64) does not match the expected platform (linux/arm64)
[root@20f4ceade635 /]# microdnf update

(microdnf:14): librhsm-WARNING **: 06:39:36.269: Found 0 entitlement certificates

(microdnf:14): librhsm-WARNING **: 06:39:36.288: Found 0 entitlement certificates
Downloading metadata...
Downloading metadata...
Downloading metadata...
Package                                                                                               Repository                             Size
Upgrading:                                                                                                                                       
 tzdata-2024a-1.el8.noarch                                                                            ubi-8-baseos-rpms                  486.5 kB
   replacing tzdata-2023d-1.el8.noarch                                                                                                           
Transaction Summary:
 Installing:        0 packages
 Reinstalling:      0 packages
 Upgrading:         1 packages
 Obsoleting:        0 packages
 Removing:          0 packages
 Downgrading:       0 packages
Downloading packages...
Running transaction test...
Updating: tzdata;2024a-1.el8;noarch;ubi-8-baseos-rpms
Cleanup: tzdata;2023d-1.el8;noarch;installed
Complete.

```

Adding microdnf step will make sure all the packages are upto date. 
