### PR TITLE
RHINENG-5297 Notification filtering

### DIFF
--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -1,0 +1,30 @@
+package api
+
+
+const timeLayout = "2006-01-02"
+
+type Collection struct {
+	Data  []interface{} `json:"data"`
+	Meta  Metadata      `json:"meta"`
+	Links Links         `json:"links"`
+}
+
+type Metadata struct {
+	Count  int `json:"count"`
+	Limit  int `json:"limit"`
+	Offset int `json:"offset"`
+}
+
+type Links struct {
+	First    string `json:"first"`
+	Previous string `json:"previous,omitempty"`
+	Next     string `json:"next,omitempty"`
+	Last     string `json:"last"`
+}
+
+var NotificationsToShow = map[string]string{
+	"323004": "NOTICE",
+	"323005": "NOTICE",
+	"324003": "NOTICE",
+	"324004": "NOTICE",
+}

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -96,7 +96,7 @@ func GetRecommendationSetList(c echo.Context) error {
 		recommendationData["workload"] = recommendation.Workload.WorkloadName
 		recommendationData["container"] = recommendation.ContainerName
 		recommendationData["last_reported"] = recommendation.Workload.Cluster.LastReportedAtStr
-		recommendationData["recommendations"] = TransformComponentUnits(recommendation.Recommendations)
+		recommendationData["recommendations"] = UpdateRecommendationJSON(recommendation.ID, recommendation.Workload.Cluster.ClusterUUID, recommendation.Recommendations)
 		allRecommendations = append(allRecommendations, recommendationData)
 
 	}
@@ -140,7 +140,7 @@ func GetRecommendationSet(c echo.Context) error {
 		recommendationSlice["workload"] = recommendationSet.Workload.WorkloadName
 		recommendationSlice["container"] = recommendationSet.ContainerName
 		recommendationSlice["last_reported"] = recommendationSet.Workload.Cluster.LastReportedAtStr
-		recommendationSlice["recommendations"] = TransformComponentUnits(recommendationSet.Recommendations)
+		recommendationSlice["recommendations"] = UpdateRecommendationJSON(recommendationSet.ID, recommendationSet.Workload.Cluster.ClusterUUID, recommendationSet.Recommendations)
 	}
 
 	return c.JSON(http.StatusOK, recommendationSlice)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -353,6 +353,8 @@ func transformComponentUnits(recommendationJSON map[string]interface{}) map[stri
 
 func filterNotifications(recommendationID string, clusterUUID string, recommendationJSON map[string]interface{}) map[string]interface{} {
 
+	var droppedNotifications []string
+
 	deleteNotificationObject := func(recommendationSection map[string]interface{}) {
 		notificationObject, ok := recommendationSection["notifications"].(map[string]interface{})
 		if ok {
@@ -360,7 +362,7 @@ func filterNotifications(recommendationID string, clusterUUID string, recommenda
 				_, found := NotificationsToShow[key]
 				if !found {
 					delete(recommendationSection, "notifications")
-					log.Warnf("dropped notification %s dropped from recommendation ID: %s; cluster ID: %s", key, recommendationID, clusterUUID)
+					droppedNotifications = append(droppedNotifications, key)
 				}
 			}
 		}
@@ -393,6 +395,9 @@ func filterNotifications(recommendationID string, clusterUUID string, recommenda
 			}
 		}
 	}
+	droppedNotificationsString := strings.Join(droppedNotifications, ", ")
+	log.Warnf("%s dropped from recommendation ID: %s; cluster ID: %s", droppedNotificationsString, recommendationID, clusterUUID)
+
 	return recommendationJSON
 }
 

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -16,34 +16,6 @@ import (
 	"github.com/redhatinsights/ros-ocp-backend/internal/logging"
 )
 
-const timeLayout = "2006-01-02"
-
-var NotificationsToShow = map[string]string{
-	"323004": "NOTICE",
-	"323005": "NOTICE",
-	"324003": "NOTICE",
-	"324004": "NOTICE",
-}
-
-type Collection struct {
-	Data  []interface{} `json:"data"`
-	Meta  Metadata      `json:"meta"`
-	Links Links         `json:"links"`
-}
-
-type Metadata struct {
-	Count  int `json:"count"`
-	Limit  int `json:"limit"`
-	Offset int `json:"offset"`
-}
-
-type Links struct {
-	First    string `json:"first"`
-	Previous string `json:"previous,omitempty"`
-	Next     string `json:"next,omitempty"`
-	Last     string `json:"last"`
-}
-
 func CollectionResponse(collection []interface{}, req *http.Request, count, limit, offset int) *Collection {
 	var first, previous, next, last string
 	q := req.URL.Query()
@@ -228,12 +200,6 @@ func transformComponentUnits(recommendationJSON map[string]interface{}) map[stri
 		bytes -> MiB -> GiB
 		cores -> millicores
 	*/
-	var data map[string]interface{}
-	err := json.Unmarshal([]byte(jsonData), &data)
-	if err != nil {
-		fmt.Printf("unable to unmarshall recommendation json")
-		return nil
-	}
 
 	convertMemory := func(memory map[string]interface{}) error {
 		amount, ok := memory["amount"].(float64)

--- a/openapi.json
+++ b/openapi.json
@@ -387,7 +387,23 @@
         "properties": {
           "duration_in_hours": {
             "type": "number",
-            "example": 24.7
+            "example": 360
+          },
+          "monitoring_start_time": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2023-06-02T00:45:00Z"
+          },
+          "recommendation_engines": {
+            "type": "object",
+            "properties": {
+              "cost": {
+                "$ref": "#/components/schemas/CostRecommendation"
+              },
+              "performance": {
+                "$ref": "#/components/schemas/PerformanceRecommendation"
+              }
+            }
           }
         }
       },
@@ -396,7 +412,23 @@
         "properties": {
           "duration_in_hours": {
             "type": "number",
-            "example": 24.7
+            "example": 168
+          },
+          "monitoring_start_time": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2023-06-02T00:45:00Z"
+          },
+          "recommendation_engines": {
+            "type": "object",
+            "properties": {
+              "cost": {
+                "$ref": "#/components/schemas/CostRecommendation"
+              },
+              "performance": {
+                "$ref": "#/components/schemas/PerformanceRecommendation"
+              }
+            }
           }
         }
       },

--- a/openapi.json
+++ b/openapi.json
@@ -352,23 +352,6 @@
                 "type": "string",
                 "format": "date-time"
               },
-              "notifications": {
-                "type": "object",
-                "properties": {
-                  "type": {
-                    "type": "string",
-                    "example": "info"
-                  },
-                  "code": {
-                    "type": "integer",
-                    "example": 111101
-                  },
-                  "message": {
-                    "type": "string",
-                    "example": "Short Term Recommendations Available"
-                  }
-                }
-              },
               "recommendation_terms": {
                 "type": "object",
                 "properties": {
@@ -405,33 +388,6 @@
           "duration_in_hours": {
             "type": "number",
             "example": 24.7
-          },
-          "monitoring_start_time": {
-            "type": "string",
-            "format": "date-time",
-            "example": "0001-01-01T00:00:00Z"
-          },
-          "notifications": {
-            "type": "object",
-            "properties": {
-              "120001": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "integer",
-                    "example": 120001
-                  },
-                  "message": {
-                    "type": "string",
-                    "example": "There is not enough data available to generate a recommendation."
-                  },
-                  "type": {
-                    "type": "string",
-                    "example": "info"
-                  }
-                }
-              }
-            }
           }
         }
       },
@@ -441,33 +397,6 @@
           "duration_in_hours": {
             "type": "number",
             "example": 24.7
-          },
-          "monitoring_start_time": {
-            "type": "string",
-            "format": "date-time",
-            "example": "0001-01-01T00:00:00Z"
-          },
-          "notifications": {
-            "type": "object",
-            "properties": {
-              "120001": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "integer",
-                    "example": 120001
-                  },
-                  "message": {
-                    "type": "string",
-                    "example": "There is not enough data available to generate a recommendation."
-                  },
-                  "type": {
-                    "type": "string",
-                    "example": "info"
-                  }
-                }
-              }
-            }
           }
         }
       },
@@ -481,46 +410,7 @@
           "monitoring_start_time": {
             "type": "string",
             "format": "date-time",
-            "example": "0001-01-01T00:00:00Z"
-          },
-          "notifications": {
-            "type": "object",
-            "properties": {
-              "112101": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "integer",
-                    "example": 112101
-                  },
-                  "message": {
-                    "type": "string",
-                    "example": "Cost Recommendations Available"
-                  },
-                  "type": {
-                    "type": "string",
-                    "example": "info"
-                  }
-                }
-              },
-              "112102": {
-                "type": "object",
-                "properties": {
-                  "code": {
-                    "type": "integer",
-                    "example": 112102
-                  },
-                  "message": {
-                    "type": "string",
-                    "example": "Performance Recommendations Available"
-                  },
-                  "type": {
-                    "type": "string",
-                    "example": "info"
-                  }
-                }
-              }
-            }
+            "example": "2023-06-02T00:45:00Z"
           },
           "recommendation_engines": {
             "type": "object",


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

API response should include a predetermined list of notifications.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

### Logs
```
WARN[0002]~/ros-ocp-backend/internal/api/utils.go:386 github.com/redhatinsights/ros-ocp-backend/internal/api.filterNotifications.func1() dropped notification 111101 dropped from recommendation ID: 3fdaae29-57f9-4782-b7be-646ef45dad68; cluster ID: 222  service=rosocp
```

Note: There seems to be too many logs per recommendation

Above issue is now addressed.

```
WARN[0019]~/ros-ocp-backend/internal/api/utils.go:396 github.com/redhatinsights/ros-ocp-backend/internal/api.filterNotifications() 111101, 112101, 112102, 120001, 120001 dropped from recommendation ID: 66d1445b-976a-4e8b-9013-56111973044f; cluster ID: 222  service=rosocp

```
