### PR TITLE
Fixes #RHINENG-5352 - Implementing delete API of kruize

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -195,6 +195,10 @@ objects:
             value: "rosocp-housekeeper"
           - name: LOG_LEVEL
             value: ${LOG_LEVEL}
+          - name: KRUIZE_HOST
+            value: ${KRUIZE_HOST}
+          - name: KRUIZE_PORT
+            value: ${KRUIZE_PORT}
 
     jobs:
       - name: delete-rosocp-partitions

--- a/internal/model/workload.go
+++ b/internal/model/workload.go
@@ -44,3 +44,10 @@ func (w *Workload) CreateWorkload() error {
 
 	return nil
 }
+
+func GetWorkloadsByClusterID(cluster_id uint) ([]Workload, error) {
+	var workloads []Workload
+	db := database.GetDB()
+	err := db.Where("cluster_id = ?", cluster_id).Find(&workloads).Error
+	return workloads, err
+}

--- a/internal/services/housekeeper/sourcesCleaner.go
+++ b/internal/services/housekeeper/sourcesCleaner.go
@@ -2,7 +2,6 @@ package housekeeper
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"strconv"
 
@@ -50,7 +49,6 @@ func sourcesListener(msg *k.Message, _ *k.Consumer) {
 			}
 			if data.Application_type_id == cost_app_id {
 				var cluster model.Cluster
-				fmt.Println(data.Source_id)
 				db.Where("source_id = ?", strconv.Itoa(data.Source_id)).First(&cluster)
 				workloads, err := model.GetWorkloadsByClusterID(cluster.ID)
 				if err != nil {

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -198,6 +198,12 @@ func Is_valid_recommendation(recommendation kruizePayload.Recommendation, experi
 }
 
 func Delete_experiment_from_kruize(experiment_name string) {
+
+	deletion_err_log := func(err error) {
+		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
+		log.Errorf("error occured while deleting experiment: %s. Error - %s", experiment_name, err)
+	}
+
 	url := cfg.KruizeUrl + "/createExperiment"
 	data := []map[string]string{
 		{"experiment_name": experiment_name},
@@ -207,21 +213,18 @@ func Delete_experiment_from_kruize(experiment_name string) {
 	client := &http.Client{}
 	req, err := http.NewRequest("DELETE", url, bytes.NewBuffer(payload))
 	if err != nil {
-		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
-		log.Error("error occured while deleting experiment: ", err)
+		deletion_err_log(err)
 		return
 	}
 	res, err := client.Do(req)
 	if err != nil {
-		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
-		log.Error("error occured while deleting experiment: ", err)
+		deletion_err_log(err)
 		return
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 201 {
 		log.Infof("Experiment - %s deleted successfully", experiment_name)
 	} else {
-		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
-		log.Error("error occured while deleting experiment: ", err)
+		deletion_err_log(err)
 	}
 }

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -196,3 +196,32 @@ func Is_valid_recommendation(recommendation kruizePayload.Recommendation, experi
 		return false
 	}
 }
+
+func Delete_experiment_from_kruize(experiment_name string) {
+	url := cfg.KruizeUrl + "/createExperiment"
+	data := []map[string]string{
+		{"experiment_name": experiment_name},
+	}
+	payload, err := json.Marshal(data)
+	if err != nil {
+		log.Error("unable to marshal payload to json: ", err)
+		return
+	}
+
+	client := &http.Client{}
+	req, err := http.NewRequest("DELETE", url, bytes.NewBuffer(payload))
+	if err != nil {
+		log.Error("unable to create request object ", err)
+		return
+	}
+	res, err := client.Do(req)
+	if err != nil {
+		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
+		log.Error("error Occured while deleting experiment: ", err)
+		return
+	}
+	defer res.Body.Close()
+	if res.StatusCode == 201 {
+		log.Infof("Experiment - %s deleted successfully", experiment_name)
+	}
+}

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -202,26 +202,26 @@ func Delete_experiment_from_kruize(experiment_name string) {
 	data := []map[string]string{
 		{"experiment_name": experiment_name},
 	}
-	payload, err := json.Marshal(data)
-	if err != nil {
-		log.Error("unable to marshal payload to json: ", err)
-		return
-	}
+	payload, _ := json.Marshal(data)
 
 	client := &http.Client{}
 	req, err := http.NewRequest("DELETE", url, bytes.NewBuffer(payload))
 	if err != nil {
-		log.Error("unable to create request object ", err)
+		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
+		log.Error("error occured while deleting experiment: ", err)
 		return
 	}
 	res, err := client.Do(req)
 	if err != nil {
 		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
-		log.Error("error Occured while deleting experiment: ", err)
+		log.Error("error occured while deleting experiment: ", err)
 		return
 	}
 	defer res.Body.Close()
 	if res.StatusCode == 201 {
 		log.Infof("Experiment - %s deleted successfully", experiment_name)
+	} else {
+		kruizeAPIException.WithLabelValues("/deleteExperiment").Inc()
+		log.Error("error occured while deleting experiment: ", err)
 	}
 }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

To delete the kruize side data when source is deleted from console.redhat.com. 

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added
