### PR TITLE
Update kruize config to include cloudwatch service

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -269,6 +269,6 @@ parameters:
 - name: KRUIZE_PARTITION_INTERVAL
   value: "0 0 * * *" # Run the cronjob every day at midnight. Earlier it was set for 16th day
 - name: KRUIZE_CW_LOG_STREAM
-  value: "kruize-stream"
+  value: "kruize-recommendations"
 - name: KRUIZE_CW_LOGGING_LEVEL
   value: "INFO"

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -93,9 +93,9 @@ objects:
             value: "UTC"
           - name: SSL_CERT_DIR
             value: ${SSL_CERT_DIR}
-          - name: cloudwatch_logStream
+          - name: logging_cloudwatch_logStream
             value: ${KRUIZE_CW_LOG_STREAM}
-          - name: cloudwatch_logLevel
+          - name: logging_cloudwatch_logLevel
             value: ${KRUIZE_CW_LOGGING_LEVEL}
     jobs:
       - name: delete-kruize-partitions

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -93,6 +93,12 @@ objects:
             value: "UTC"
           - name: SSL_CERT_DIR
             value: ${SSL_CERT_DIR}
+          - name: cloudwatch_logGroup
+            value: ${KRUIZE_CW_LOG_GROUP}
+          - name: cloudwatch_logStream
+            value: ${KRUIZE_CW_LOG_STREAM}
+          - name: cloudwatch_logLevel
+            value: ${KRUIZE_CW_LOGGING_LEVEL}
     jobs:
       - name: delete-kruize-partitions
         schedule: ${KRUIZE_PARTITION_INTERVAL}
@@ -264,3 +270,9 @@ parameters:
   value: "info"
 - name: KRUIZE_PARTITION_INTERVAL
   value: "0 0 * * *" # Run the cronjob every day at midnight. Earlier it was set for 16th day
+- name: KRUIZE_CW_LOG_GROUP
+  value: "rosocp"
+- name: KRUIZE_CW_LOG_STREAM
+  value: "kruize-stream"
+- name: KRUIZE_CW_LOGGING_LEVEL
+  value: "INFO"

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -19,7 +19,7 @@ objects:
       podSpec:
         image: ${KRUIZE_IMAGE}:${KRUIZE_IMAGE_TAG}
         command: ["sh"]
-        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && bash target/bin/Autotune"]
+        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && export KRUIZE_CONFIG_FILE=${KCW_CONFIG} && bash target/bin/Autotune"]
         machinePool: ${MACHINE_POOL_OPTION}
         resources:
           requests:
@@ -93,8 +93,6 @@ objects:
             value: "UTC"
           - name: SSL_CERT_DIR
             value: ${SSL_CERT_DIR}
-          - name: cloudwatch_logGroup
-            value: ${KRUIZE_CW_LOG_GROUP}
           - name: cloudwatch_logStream
             value: ${KRUIZE_CW_LOG_STREAM}
           - name: cloudwatch_logLevel
@@ -270,8 +268,6 @@ parameters:
   value: "info"
 - name: KRUIZE_PARTITION_INTERVAL
   value: "0 0 * * *" # Run the cronjob every day at midnight. Earlier it was set for 16th day
-- name: KRUIZE_CW_LOG_GROUP
-  value: "rosocp"
 - name: KRUIZE_CW_LOG_STREAM
   value: "kruize-stream"
 - name: KRUIZE_CW_LOGGING_LEVEL

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -19,7 +19,7 @@ objects:
       podSpec:
         image: ${KRUIZE_IMAGE}:${KRUIZE_IMAGE_TAG}
         command: ["sh"]
-        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && export KRUIZE_CONFIG_FILE=${KCW_CONFIG} && bash target/bin/Autotune"]
+        args: ["-c", "export DB_CONFIG_FILE=${ACG_CONFIG} && export KRUIZE_CONFIG_FILE=${ACG_CONFIG} && bash target/bin/Autotune"]
         machinePool: ${MACHINE_POOL_OPTION}
         resources:
           requests:

--- a/scripts/kruizecloudwatchcofig.json
+++ b/scripts/kruizecloudwatchcofig.json
@@ -1,0 +1,8 @@
+{
+  "cloudwatch": {
+    "accessKeyId": "",
+    "logGroup": "",
+    "region": "",
+    "secretAccessKey": ""
+  }
+}

--- a/scripts/kruizecloudwatchcofig.json
+++ b/scripts/kruizecloudwatchcofig.json
@@ -1,8 +1,0 @@
-{
-  "cloudwatch": {
-    "accessKeyId": "",
-    "logGroup": "",
-    "region": "",
-    "secretAccessKey": ""
-  }
-}


### PR DESCRIPTION
## Update kruize config to include cloudwatch service

## Why do we need this change? :thought_balloon:

Include the ENV changes of Kruize to include Cloudwatch configuration.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no: <Yet to release>
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added