### PR TITLE
RHINENG-9376 Assert workload before relating recommendation record

### DIFF
--- a/internal/model/workload.go
+++ b/internal/model/workload.go
@@ -51,3 +51,10 @@ func GetWorkloadsByClusterID(cluster_id uint) ([]Workload, error) {
 	err := db.Where("cluster_id = ?", cluster_id).Find(&workloads).Error
 	return workloads, err
 }
+
+func WorkloadExistsByID(workload_id uint) bool {
+	var workload Workload
+	db := database.GetDB()
+	err := db.First(&workload, workload_id).Error
+	return err == nil
+}

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -182,6 +182,8 @@ func PollForRecommendations(msg *kafka.Message, consumer_object *kafka.Consumer)
 			}
 			return
 		}
+	} else {
+		commitKafkaMsg(msg, consumer_object)
 	}
 
 }

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -176,6 +176,9 @@ func PollForRecommendations(msg *kafka.Message, consumer_object *kafka.Consumer)
 				} else {
 					commitKafkaMsg(msg, consumer_object)
 				}
+			} else {
+				commitKafkaMsg(msg, consumer_object)
+				log.Warn("monitoring_end_time is set to 0001-01-01 00:00:00 +0000; recommendationID: ", recommendation_stored_in_db.ID)
 			}
 			return
 		}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:
Looks like poller tries to save a recomm. for which workload was deleted potentially by the housekeeper service.
Additionally, I didn't find any workloads when searching with the ids from logs via Gabi.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [x] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

More details added in JIRA card