### PR TITLE
RHINENG-10285 Restore PLOTS_DATA env var

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -101,6 +101,8 @@ objects:
             value: ${KRUIZE_CW_LOG_STREAM}
           - name: logging_cloudwatch_logLevel
             value: ${KRUIZE_CW_LOGGING_LEVEL}
+          - name: plots
+            value: ${PLOTS_DATA}
     jobs:
       - name: delete-kruize-partitions
         schedule: ${KRUIZE_PARTITION_INTERVAL}
@@ -276,4 +278,6 @@ parameters:
   value: "kruize-recommendations"
 - name: KRUIZE_CW_LOGGING_LEVEL
   value: "INFO"
+- name: PLOTS_DATA
+  value: "false"
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Kruize 0.0.22 still requires `plots` environment variable

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.