### PR TITLE
Fixes #RHCLOUD-33105 - Modified kafka consumer config for non-SSL broker

### DIFF
--- a/internal/kafka/consumer.go
+++ b/internal/kafka/consumer.go
@@ -39,8 +39,6 @@ func StartConsumer(kafka_topic string, handler func(msg *kafka.Message, consumer
 			"enable.auto.commit":       auto_commit,
 			"go.logs.channel.enable":   true,
 			"allow.auto.create.topics": true,
-			"session.timeout.ms":       120000,
-			"heartbeat.interval.ms":    30000,
 		}
 
 		// As per librdkafka doc - https://github.com/confluentinc/librdkafka/blob/master/CONFIGURATION.md?plain=1#L73
@@ -58,6 +56,9 @@ func StartConsumer(kafka_topic string, handler func(msg *kafka.Message, consumer
 			"allow.auto.create.topics": true,
 		}
 	}
+
+	configMap["session.timeout.ms"] = 120000
+	configMap["heartbeat.interval.ms"] = 30000
 
 	consumer, err := kafka.NewConsumer(&configMap)
 	if err != nil {


### PR DESCRIPTION
As per comment on the JIRA ticket we need to add custom kafka consumer config for non-auth environments. 

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.