### PR TITLE
RHINENG-10671  API should return k8s units for values

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -118,6 +118,18 @@ func GetRecommendationSetList(c echo.Context) error {
 		log.Error("unable to fetch records from database", error)
 	}
 
+	trueUnitsStr := c.QueryParam("true-units")
+	var trueUnits bool
+
+	if trueUnitsStr != "" {
+		trueUnits, err = strconv.ParseBool(trueUnitsStr)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": "invalid value for true-units"})
+		}
+	}
+	
+	setk8sUnits := !trueUnits
+
 	allRecommendations := []map[string]interface{}{}
 
 	for _, recommendation := range recommendationSets {
@@ -132,7 +144,7 @@ func GetRecommendationSetList(c echo.Context) error {
 		recommendationData["workload"] = recommendation.Workload.WorkloadName
 		recommendationData["container"] = recommendation.ContainerName
 		recommendationData["last_reported"] = recommendation.Workload.Cluster.LastReportedAtStr
-		recommendationData["recommendations"] = UpdateRecommendationJSON(handlerName, recommendation.ID, recommendation.Workload.Cluster.ClusterUUID, unitChoices, recommendation.Recommendations)
+		recommendationData["recommendations"] = UpdateRecommendationJSON(handlerName, recommendation.ID, recommendation.Workload.Cluster.ClusterUUID, unitChoices, setk8sUnits, recommendation.Recommendations)
 		allRecommendations = append(allRecommendations, recommendationData)
 
 	}
@@ -159,6 +171,18 @@ func GetRecommendationSet(c echo.Context) error {
 	}
 
 	var unitChoices = make(map[string]string)
+
+	trueUnitsStr := c.QueryParam("true-units")
+	var trueUnits bool
+
+	if trueUnitsStr != "" {
+		trueUnits, err = strconv.ParseBool(trueUnitsStr)
+		if err != nil {
+			return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": "invalid value for true-units"})
+		}
+	}
+	
+	setk8sUnits := !trueUnits
 
 	cpuUnitParam := c.QueryParam("cpu-unit")
 	var cpuUnitOptions = map[string]bool{
@@ -212,7 +236,7 @@ func GetRecommendationSet(c echo.Context) error {
 		recommendationSlice["workload"] = recommendationSet.Workload.WorkloadName
 		recommendationSlice["container"] = recommendationSet.ContainerName
 		recommendationSlice["last_reported"] = recommendationSet.Workload.Cluster.LastReportedAtStr
-		recommendationSlice["recommendations"] = UpdateRecommendationJSON(handlerName, recommendationSet.ID, recommendationSet.Workload.Cluster.ClusterUUID, unitChoices, recommendationSet.Recommendations)
+		recommendationSlice["recommendations"] = UpdateRecommendationJSON(handlerName, recommendationSet.ID, recommendationSet.Workload.Cluster.ClusterUUID, unitChoices, setk8sUnits, recommendationSet.Recommendations)
 	}
 
 	return c.JSON(http.StatusOK, recommendationSlice)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -242,7 +242,7 @@ func convertMemoryUnit(memoryUnit string, memoryValue float64) float64 {
 
 }
 
-func transformComponentUnits(unitsToTransform map[string]string, recommendationJSON map[string]interface{}) map[string]interface{} {
+func transformComponentUnits(unitsToTransform map[string]string, updateUnitsk8s bool, recommendationJSON map[string]interface{}) map[string]interface{} {
 	/*
 		Truncates CPU units(cores) to three decimal places
 		Truncates Memory units(Mi) to two decimal places
@@ -275,7 +275,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 					memoryUnit := unitsToTransform["memory"]
 					convertedMemoryValue := convertMemoryUnit(memoryUnit, memoryValue)
 					memoryObject["amount"] = convertedMemoryValue
-					memoryObject["format"] = MemoryUnitk8s[memoryUnit]
+					if updateUnitsk8s {
+						memoryObject["format"] = MemoryUnitk8s[memoryUnit]
+					} else {
+						memoryObject["format"] = memoryUnit
+					}
 				}
 			}
 
@@ -285,7 +289,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 					cpuUnit := unitsToTransform["cpu"]
 					convertedCPUValue := convertCPUUnit(cpuUnit, cpuValue)
 					cpuObject["amount"] = convertedCPUValue
-					cpuObject["format"] = CPUUnitk8s[cpuUnit]
+					if updateUnitsk8s {
+						cpuObject["format"] = CPUUnitk8s[cpuUnit]
+					} else {
+						cpuObject["format"] = cpuUnit
+					}
 				}
 			}
 		}
@@ -333,7 +341,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 						if cpuUsage, ok := datapointMap["cpuUsage"].(map[string]interface{}); ok {
 							cpuUnit := unitsToTransform["cpu"]
 							if _, ok := cpuUsage["format"].(string); ok {
-								cpuUsage["format"] = cpuUnit
+								if updateUnitsk8s {
+									cpuUsage["format"] = CPUUnitk8s[cpuUnit]
+								} else {
+									cpuUsage["format"] = cpuUnit
+								}
 							}
 							for _, key := range []string{"q1", "q3", "min", "max", "median"} {
 								cpuValue, _ := cpuUsage[key].(float64)
@@ -343,7 +355,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 						if memoryUsage, ok := datapointMap["memoryUsage"].(map[string]interface{}); ok {
 							memoryUnit := unitsToTransform["memory"]
 							if _, ok := memoryUsage["format"].(string); ok {
-								memoryUsage["format"] = memoryUnit
+								if updateUnitsk8s {
+									memoryUsage["format"] = MemoryUnitk8s[memoryUnit]
+								} else {
+									memoryUsage["format"] = memoryUnit
+								}
 							}
 							for _, key := range []string{"q1", "q3", "min", "max", "median"} {
 								memoryValue, _ := memoryUsage[key].(float64)
@@ -380,7 +396,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 									memoryUnit := unitsToTransform["memory"]
 									convertedMemoryValue := convertMemoryUnit(memoryUnit, memoryValue)
 									memoryObject["amount"] = convertedMemoryValue
-									memoryObject["format"] = MemoryUnitk8s[memoryUnit]
+									if updateUnitsk8s {
+										memoryObject["format"] = MemoryUnitk8s[memoryUnit]
+									} else {
+										memoryObject["format"] = memoryUnit
+									}
 								}
 							}
 
@@ -390,7 +410,11 @@ func transformComponentUnits(unitsToTransform map[string]string, recommendationJ
 									cpuUnit := unitsToTransform["cpu"]
 									convertedCPUValue := convertCPUUnit(cpuUnit, cpuValue)
 									cpuObject["amount"] = convertedCPUValue
-									cpuObject["format"] = CPUUnitk8s[cpuUnit]
+									if updateUnitsk8s {
+										cpuObject["format"] = CPUUnitk8s[cpuUnit]
+									} else {
+										cpuObject["format"] = cpuUnit
+									}
 								}
 
 							}
@@ -589,7 +613,7 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}) map
 	return recommendationJSON
 }
 
-func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, jsonData datatypes.JSON) map[string]interface{} {
+func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, updateUnitsk8s bool, jsonData datatypes.JSON) map[string]interface{} {
 
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(jsonData), &data)
@@ -603,7 +627,7 @@ func UpdateRecommendationJSON(handlerName string, recommendationID string, clust
 		data = dropBoxPlotsObject(data)
 	}
 
-	data = transformComponentUnits(unitsToTransform, data) // cpu: core values require truncation
+	data = transformComponentUnits(unitsToTransform, updateUnitsk8s, data) // cpu: core values require truncation
 	data = filterNotifications(recommendationID, clusterUUID, data)
 	data = convertVariationToPercentage(data)
 	return data

--- a/openapi.json
+++ b/openapi.json
@@ -69,6 +69,15 @@
             }
           },
           {
+            "name": "true-units",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Shows all values in true/real-world units. Accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False."
+          },
+          {
             "name": "start_date",
             "in": "query",
             "description": "Start date",
@@ -204,6 +213,15 @@
               "type": "string"
             },
             "description": "The recommendation UUID"
+          },
+          {
+            "name": "true-units",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Shows all values in true/real-world units. Accepts 1, t, T, TRUE, true, True, 0, f, F, FALSE, false, False."
           },
           {
             "in": "query",


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:
Update 2:

We are switching to a boolean value param, i.e. `true-units=true/false`.
This is due to an OpenAPI limitation, there is no native way to define a value-less boolean param in the spec.

--------------------------------------------------

Update:

Since we are switching to k8s units by default, `k8s-units` has been replaced by `true-units`.
It is a boolean param, presence denotes `true`. Since we can expect a k8s service to show values in k8s units the introduction and usage of `true-units` makes a bit more sense.
Thank you @kgaikwad for the suggestion.

---------------------------------------------------
> The API is reporting values in K8S supported units for the UI to avoid any unit string manipulation in the recommendation section.
> 
> Now that we have box plots data as well, this approach no longer seems to work as expected.

As per internal discussions, the API will now return k8s units by default.

This PR includes another query parameter `k8s-units` ("true" by default).
In case users require values in real-world units the same can be set to "false" while sending the request.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Please check pinned comment on JIRA card for more details.