### PR TITLE
RHINENG-11430 Metrics for HTTP request-response cycle

### DIFF
--- a/internal/services/metrics.go
+++ b/internal/services/metrics.go
@@ -10,4 +10,12 @@ var (
 		Name: "rosocp_invalid_csv_total",
 		Help: "The total number of invalid csv send by cost-mgmt",
 	})
+	recommendationRequest = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "rosocp_recommendation_request_total",
+		Help: "The total number of recommendations requested from Kruize",
+	})
+	recommendationSuccess = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "rosocp_recommendation_success_total",
+		Help: "The total number of recommendations saved by ROSOCP",
+	})
 )

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -54,6 +54,7 @@ func transactionForRecommendation(recommendationSetList []model.RecommendationSe
 			return err
 		}
 	}
+	recommendationSuccess.Inc()
 	return tx.Commit().Error
 }
 
@@ -72,6 +73,7 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 		log.Errorf("unable to list recommendation for: %v", err)
 		return poll_cycle_complete
 	}
+	recommendationRequest.Inc()
 
 	containers := recommendation[0].Kubernetes_objects[0].Containers
 	recommendationSetList := []model.RecommendationSet{}

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -54,7 +54,6 @@ func transactionForRecommendation(recommendationSetList []model.RecommendationSe
 			return err
 		}
 	}
-	recommendationSuccess.Inc()
 	return tx.Commit().Error
 }
 
@@ -116,6 +115,7 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 		txError := transactionForRecommendation(recommendationSetList, histRecommendationSetList, experiment_name, recommendationType)
 		if txError == nil {
 			poll_cycle_complete = true
+			recommendationSuccess.Inc()
 		} else {
 			poll_cycle_complete = false
 		}

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -68,6 +68,7 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 		end_interval := utils.ConvertDateToISO8601(maxEndTimeFromReport.String())
 		if err.Error() == fmt.Sprintf("Recommendation for timestamp - \" %s \" does not exist", end_interval) {
 			log.Infof("recommendation does not exist for timestamp - \" %s \"", end_interval)
+			recommendationRequest.Inc()
 		}
 		log.Errorf("unable to list recommendation for: %v", err)
 		return poll_cycle_complete

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -84,7 +84,7 @@ func Create_kruize_experiments(experiment_name string, cluster_identifier string
 			return nil, fmt.Errorf("%s", resdata["message"])
 		}
 	}
-
+	createExperimentRequest.Inc()
 	container_names := make([]string, 0, len(containers))
 	for _, value := range containers {
 		container_names = append(container_names, value["container_name"])
@@ -139,6 +139,7 @@ func Update_results(experiment_name string, payload_data []kruizePayload.UpdateR
 		}
 	}
 
+	updateResultRequest.Inc()
 	return payload_data, nil
 }
 

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -54,6 +54,7 @@ func Create_kruize_experiments(experiment_name string, cluster_identifier string
 		kruizeAPIException.WithLabelValues("/createExperiment").Inc()
 		return nil, fmt.Errorf("error Occured while creating experiment: %v", err)
 	}
+	createExperimentRequest.Inc()
 	if res.StatusCode != 201 {
 		defer res.Body.Close()
 		body, _ := io.ReadAll(res.Body)
@@ -84,7 +85,6 @@ func Create_kruize_experiments(experiment_name string, cluster_identifier string
 			return nil, fmt.Errorf("%s", resdata["message"])
 		}
 	}
-	createExperimentRequest.Inc()
 	container_names := make([]string, 0, len(containers))
 	for _, value := range containers {
 		container_names = append(container_names, value["container_name"])
@@ -107,6 +107,7 @@ func Update_results(experiment_name string, payload_data []kruizePayload.UpdateR
 		kruizeAPIException.WithLabelValues("/updateResults").Inc()
 		return nil, fmt.Errorf("an Error Occured while sending metrics: %v", err)
 	}
+	updateResultRequest.Inc()
 	defer res.Body.Close()
 	body, _ := io.ReadAll(res.Body)
 	log.Debugf("\n Respose from API /updateResult - %s \n", string(body))
@@ -139,7 +140,6 @@ func Update_results(experiment_name string, payload_data []kruizePayload.UpdateR
 		}
 	}
 
-	updateResultRequest.Inc()
 	return payload_data, nil
 }
 

--- a/internal/utils/kruize/metrics.go
+++ b/internal/utils/kruize/metrics.go
@@ -18,10 +18,10 @@ var (
 	})
 	createExperimentRequest = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "kruize_create_experiment_request_total",
-		Help: "The total number of experiments created on Kruize",
+		Help: "The total number of experiment creation requests sent to Kruize",
 	})
 	updateResultRequest = promauto.NewCounter(prometheus.CounterOpts{
 		Name: "kruize_update_result_request_total",
-		Help: "The total number of requests/csvs sent to Kruize for UpdateResult",
+		Help: "The total number of requests sent to Kruize for UpdateResult",
 	})
 )

--- a/internal/utils/kruize/metrics.go
+++ b/internal/utils/kruize/metrics.go
@@ -16,4 +16,12 @@ var (
 		Name: "rosocp_invalid_recommendation_total",
 		Help: "The total number of invalid recommendation send by Kruize",
 	})
+	createExperimentRequest = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "kruize_create_experiment_request_total",
+		Help: "The total number of experiments created on Kruize",
+	})
+	updateResultRequest = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "kruize_update_result_request_total",
+		Help: "The total number of requests/csvs sent to Kruize for UpdateResult",
+	})
 )


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Capture the following metrics w.r.t request and response cycle between ROS OCP and Kruize on Prometheus.

- kruize_create_experiment_request_total
- kruize_update_result_request_total
- rosocp_recommendation_request_total
- rosocp_recommendation_success_total


## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:
![image](https://github.com/user-attachments/assets/c60e6447-64af-4c62-b65e-44892faaa2c5)

Please check JIRA card for additional details.