### PR TITLE
RHINENG-16692 Omit pods_count field in recommendations

### DIFF
--- a/internal/types/kruizePayload/common.go
+++ b/internal/types/kruizePayload/common.go
@@ -50,11 +50,14 @@ type Notification struct {
 }
 
 type RecommendationEngineObject struct {
-	PodsCount       int                     `json:"pods_count,omitempty"`
-	ConfidenceLevel float64                 `json:"confidence_level,omitempty"`
-	Config          ConfigObject            `json:"config,omitempty"`
-	Variation       ConfigObject            `json:"variation,omitempty"`
-	Notifications   map[string]Notification `json:"notifications"`
+	/*
+		Following fields/features from Kruize are at their nascent stages
+		PodsCount       int                     `json:"pods_count,omitempty"`
+		ConfidenceLevel float64                 `json:"confidence_level,omitempty"`
+	*/
+	Config        ConfigObject            `json:"config,omitempty"`
+	Variation     ConfigObject            `json:"variation,omitempty"`
+	Notifications map[string]Notification `json:"notifications"`
 }
 
 type RecommendationData struct {

--- a/openapi.json
+++ b/openapi.json
@@ -723,10 +723,6 @@
               }
             ]
           },
-          "pods_count": {
-            "type": "integer",
-            "example": 1
-          },
           "variation": {
             "type": "object",
             "properties": {
@@ -891,10 +887,6 @@
                 "$ref": "#/components/schemas/NilNotification"
               }
             ]
-          },
-          "pods_count": {
-            "type": "integer",
-            "example": 1
           },
           "variation": {
             "type": "object",


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

`pods_count` field/feature from Kruize is still at it's nascent stages

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

`confidence_level` was already hidden from API responses due to the `omitempty` tag as Kruize has been responding with 0 for the field.

Removing the fields from respective struct is a standard way to ensure the `key;value` never gets captured and saved to database by ROS OCP.