### PR TITLE
Update kruize image reference and image; docker-compose

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/cloudservices/autotune:34a6020
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:b536779
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:
@@ -135,7 +135,7 @@ services:
       - QUEUE_PORT=29092
     depends_on:
       - db-sources
-      
+
   sources-api-go:
     image: quay.io/cloudservices/sources-api-go
     command: ""


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Update kruize image reference and image; docker-compose
A minor \n formatting change

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Update Kruize autotune image reference in docker-compose configuration

Enhancements:
- Update the Kruize autotune image to a new version in the docker-compose file

Chores:
- Minor formatting adjustment in docker-compose configuration