### PR TITLE
Remove scheduling from obsolete GH Action

### DIFF
--- a/.github/workflows/test-ros-kruize-rm.yml
+++ b/.github/workflows/test-ros-kruize-rm.yml
@@ -1,8 +1,6 @@
 name: EE Dry Run - Latest Kruize image
 
 on:
-  schedule:
-    - cron: "5 0 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

EE Dry run workflow is creating un-necessary PRs

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Remove scheduled workflow trigger for EE Dry Run GitHub Action

CI:
- Disabled scheduled GitHub Action workflow, keeping only manual workflow dispatch trigger

Chores:
- Removed automatic daily scheduling for the EE Dry Run workflow