### PR TITLE
Updated kruize image tag to 0.6 release

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "0be85a8"
+  value: "d0b4337"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:0be85a8
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d0b4337
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
Updated kruize image tag to 0.6 release

## Summary by Sourcery

Enhancements:
- Bump Kruize container image tag in ClowdApp and Docker Compose configurations to the new 0.6 release SHA.