### PR TITLE
RHINENG-14770 - fix dashboard with active datasources

### DIFF
--- a/dashboards/grafana-dashboard-insights-rosocp-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rosocp-general.configmap.yaml
@@ -1291,8 +1291,8 @@ data:
           {
             "current": {
               "selected": true,
-              "text": "app-sre-prod-01-prometheus",
-              "value": "app-sre-prod-01-prometheus"
+              "text": "appsrep11ue1-prometheus",
+              "value": "P677746A44F299DAF"
             },
             "hide": 0,
             "includeAll": false,
@@ -1303,7 +1303,7 @@ data:
             "query": "prometheus",
             "queryValue": "",
             "refresh": 1,
-            "regex": "app-sre-stage-01-prometheus|app-sre-prod-01-prometheus",
+            "regex": "(appsrep11ue1|appsres11ue1)-prometheus",
             "skipUrlSync": false,
             "type": "datasource"
           },
@@ -1388,7 +1388,7 @@ data:
       "timezone": "",
       "title": "ROSOCP",
       "uid": "ofxxAX0nk",
-      "version": 1,
+      "version": 2,
       "weekStart": ""
     }
 kind: ConfigMap


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title
3. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Update the Grafana ROSOCP dashboard config to reference active Prometheus datasources and increment its version

Bug Fixes:
- Update default Prometheus datasource in the ROSOCP Grafana dashboard configuration

Enhancements:
- Adjust datasource regex to match new active Prometheus instances
- Bump ROSOCP dashboard config version from 1 to 2