### PR TITLE
Exact match for cluster_uuid

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -166,7 +166,7 @@ func parseQueryParams(param string, values []string) (string, []string) {
 		return parsedKeyMultipleVal, valuesSlice
 	} else {
 		if param == "cluster" {
-			paramMap[param] = paramMap[param] + " OR " + "clusters.cluster_uuid ILIKE ?"
+			paramMap[param] = paramMap[param] + " OR " + "clusters.cluster_uuid = ?"
 			valuesSlice = append(valuesSlice, "%"+values[0]+"%")
 			valuesSlice = append(valuesSlice, "%"+values[0]+"%")
 		} else if param == "workload_type" {


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Logically it makes sense to have an exact match operation for an id field/column

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

NA

## Summary by Sourcery

Enhancements:
- Switch the cluster_uuid filter to use '=' for exact matching instead of case-insensitive substring matching