### PR TITLE
RHINENG-19104 Test kruize 0.7-dev backwards compatibility

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d0b4337
+    image: quay.io/kruize/autotune_operator:0.7-dev
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

kruize 0.7-dev contains namespace recommendation changes, this PR has been created just to check if it is backwards compatible with all existing functionalities through pr_check.
Local testing has been completed including verifying box plots json.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Enhancements:
- Bump kruize-autotune service image in docker-compose from d0b4337 to 0.7-dev