### PR TITLE
RHINENG-19228 `Accept` header with query param `format`

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -111,19 +111,31 @@ func GetRecommendationSetList(c echo.Context) error {
 		}
 	}
 
-	format := c.QueryParam("format")
+	acceptHeaderValue := c.Request().Header.Get("Accept")
+	format := "json" // default value
 
-	if format == "" {
-		format = "json"
-	} else {
-		formatLower := strings.ToLower(format)
-		switch formatLower {
-		case "csv":
-			format = "csv"
-		case "json":
-			format = "json"
-		default:
-			return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": "invalid value for format"})
+	switch acceptHeaderValue {
+	case "text/csv":
+		format = "csv"
+	case "application/json":
+		break
+	default:
+		formatParam := c.QueryParam("format")
+		if formatParam == "" {
+			break
+		} else {
+			formatLower := strings.ToLower(formatParam)
+			switch formatLower {
+			case "csv":
+				format = "csv"
+			case "json":
+				break
+			default:
+				format = formatLower
+				return c.JSON(http.StatusBadRequest,
+					echo.Map{"status": "error", "message": fmt.Sprintf("invalid value for format; %s", format)},
+				)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Accept header takes precendence over format query param
both `accept` and `Accept` can be interpreted by the service

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.