### PR TITLE
remove rbac as depedency - test pr_check

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -12,7 +12,6 @@ objects:
     envName: ${ENV_NAME}
     dependencies:
     - ingress
-    - rbac
     - sources-api
     deployments:
     - name: processor


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

kessel is an rbac dependency, checking if removing rbac as a dependency helps with pr check faiures.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Enhancements:
- Remove rbac as a dependency in clowdapp.yaml to streamline environment setup