### PR TITLE
Add missing DB indexes

### DIFF
--- a/migrations/000002_create_clusters_table.up.sql
+++ b/migrations/000002_create_clusters_table.up.sql
@@ -13,6 +13,3 @@ ON DELETE CASCADE;
 
 ALTER TABLE clusters
 ADD UNIQUE (tenant_id, source_id, cluster_uuid, cluster_alias);
-
--- GET Recommendations optimization
-CREATE INDEX IF NOT EXISTS idx_cluster_last_reported_at ON clusters (last_reported_at);

--- a/migrations/000003_create_workloads_table.up.sql
+++ b/migrations/000003_create_workloads_table.up.sql
@@ -20,6 +20,3 @@ CREATE INDEX idx_workloads_containers ON workloads USING gin(containers);
 
 ALTER TABLE workloads
 ADD UNIQUE (org_id, cluster_id, experiment_name);
-
--- GET Recommendations optimization
-CREATE INDEX IF NOT EXISTS idx_workloads_cluster_id ON workloads (cluster_id);

--- a/migrations/000004_create_recommendation_sets_table.up.sql
+++ b/migrations/000004_create_recommendation_sets_table.up.sql
@@ -14,6 +14,3 @@ ON DELETE CASCADE;
 
 ALTER TABLE recommendation_sets
 ADD CONSTRAINT UQ_Recommendation UNIQUE (workload_id, container_name);
-
--- GET Recommendations optimization
-CREATE INDEX IF NOT EXISTS idx_recommendation_set_workload_id ON recommendation_sets (workload_id);

--- a/migrations/000015_add_missing_optimization_indexes.down.sql
+++ b/migrations/000015_add_missing_optimization_indexes.down.sql
@@ -1,0 +1,4 @@
+
+DROP INDEX IF EXISTS idx_cluster_last_reported_at;
+DROP INDEX IF EXISTS idx_workloads_cluster_id;
+DROP INDEX IF EXISTS idx_recommendation_set_workload_id;

--- a/migrations/000015_add_missing_optimization_indexes.up.sql
+++ b/migrations/000015_add_missing_optimization_indexes.up.sql
@@ -1,0 +1,5 @@
+-- GET Recommendations optimization
+
+CREATE INDEX IF NOT EXISTS idx_cluster_last_reported_at ON clusters (last_reported_at);
+CREATE INDEX IF NOT EXISTS idx_workloads_cluster_id ON workloads (cluster_id);
+CREATE INDEX IF NOT EXISTS idx_recommendation_set_workload_id ON recommendation_sets (workload_id);


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

In the PR #282 indexes were added in existing migration files.

Gorm does not support such incremental changes via existing files unlike sqlalchemy.

Proper definition of the same indexes have addressed here.


## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added/Updated
- [x] DB Migration Added

## Additional :mega:

- NA

## Summary by Sourcery

Introduce a dedicated migration to add missing optimization indexes and upgrade Go module dependencies to their latest patch releases

Bug Fixes:
- Add missing optimization indexes for workloads.cluster_id, recommendation_sets.workload_id, and clusters.last_reported_at via a new migration file


Chores:
- Remove inline index creation statements from earlier migration scripts to support proper GORM incremental migrations