### PR TITLE
Update kruize release to 0.8.3

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "5eeae99"
+  value: "d2d9cef"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:5eeae99
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d2d9cef
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## PR Title :boom:

Update kruize release to 0.8.3 to address netty cve and upgrade to latest RH UBI minimal 10.1

## Summary by Sourcery

Bump the Kruize image tag in the clowdapp configuration to use the latest release.

Bug Fixes:
- Align the deployed Kruize image with a newer release that includes upstream security and dependency fixes.

Deployment:
- Update the Kruize container image tag in deployment configuration to point to the new release image.