### PR TITLE
RHINENG-21007 Add exclude and exact filter support for container List API

### DIFF
--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -170,6 +171,59 @@ func TestMapQueryParametersFilterClauses(t *testing.T) {
 			queryParams: map[string][]string{"exclude[container]": {"web"}, "filter[exact:container]": {"web"}},
 			wantErr:     true,
 			errContains: "exclude and exact cannot share values",
+		},
+		{
+			name:        "container partial match multiple values",
+			queryParams: map[string][]string{"container": {"web-server", "api-server"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				key := containerCol + " ILIKE ? OR " + containerCol + " ILIKE ?"
+				assert.Equal(t, []string{"%web-server%", "%api-server%"}, result[key])
+			},
+		},
+		{
+			name:        "container exact match multiple values",
+			queryParams: map[string][]string{"filter[exact:container]": {"web-server", "api-server"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				key := containerCol + " = ? OR " + containerCol + " = ?"
+				assert.Equal(t, []string{"web-server", "api-server"}, result[key])
+			},
+		},
+		{
+			name:        "workload partial match multiple values",
+			queryParams: map[string][]string{"workload": {"cart-svc", "pay-svc"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				key := workloadCol + " ILIKE ? OR " + workloadCol + " ILIKE ?"
+				assert.Equal(t, []string{"%cart-svc%", "%pay-svc%"}, result[key])
+			},
+		},
+		{
+			name:        "project partial match multiple values",
+			queryParams: map[string][]string{"project": {"ns-alpha", "ns-beta"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				key := projectContainerCol + " ILIKE ? OR " + projectContainerCol + " ILIKE ?"
+				assert.Equal(t, []string{"%ns-alpha%", "%ns-beta%"}, result[key])
+			},
+		},
+		{
+			name:        "container exceeds max length",
+			queryParams: map[string][]string{"container": {strings.Repeat("a", model.NamespaceMaxLen+1)}},
+			wantErr:     true,
+			errContains: "exceeds max length",
+		},
+		{
+			name:        "project exceeds max length",
+			queryParams: map[string][]string{"project": {strings.Repeat("a", model.NamespaceMaxLen+1)}},
+			wantErr:     true,
+			errContains: "exceeds max length",
+		},
+		{
+			name: "multiple filters exceed max length - joined errors",
+			queryParams: map[string][]string{
+				"container": {strings.Repeat("a", model.NamespaceMaxLen+1)},
+				"project":   {strings.Repeat("b", model.NamespaceMaxLen+1)},
+			},
+			wantErr:     true,
+			errContains: "exceeds max length",
 		},
 	}
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -139,6 +139,14 @@ func TestMapQueryParametersFilterClauses(t *testing.T) {
 			},
 		},
 		{
+			name:        "workload_type plain param uses exact match not partial",
+			queryParams: map[string][]string{"workload_type": {"deployment"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"deployment"}, result[workloadTypeCol+" = ?"])
+				assert.Nil(t, result[workloadTypeCol+" ILIKE ?"], "workload_type plain param must not use ILIKE")
+			},
+		},
+		{
 			name:        "workload_type exact match",
 			queryParams: map[string][]string{"filter[exact:workload_type]": {"Deployment"}},
 			checkResult: func(t *testing.T, result map[string]interface{}) {

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -78,6 +78,128 @@ func TestMapQueryParameters(t *testing.T) {
 	}
 }
 
+func TestMapQueryParametersFilterClauses(t *testing.T) {
+	containerCol := "recommendation_sets.container_name"
+	workloadCol := "workloads.workload_name"
+	workloadTypeCol := "workloads.workload_type"
+	projectContainerCol := "workloads.namespace"
+
+	tests := []struct {
+		name        string
+		queryParams map[string][]string
+		wantErr     bool
+		errContains string
+		checkResult func(t *testing.T, result map[string]interface{})
+	}{
+		{
+			name:        "container include (partial match)",
+			queryParams: map[string][]string{"container": {"web-server"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"%web-server%"}, result[containerCol+" ILIKE ?"])
+			},
+		},
+		{
+			name:        "container exact match",
+			queryParams: map[string][]string{"filter[exact:container]": {"web-server"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"web-server"}, result[containerCol+" = ?"])
+			},
+		},
+		{
+			name:        "container exclude",
+			queryParams: map[string][]string{"exclude[container]": {"web-server"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"web-server"}, result[containerCol+" != ?"])
+			},
+		},
+		{
+			name: "container exclude and exact together",
+			queryParams: map[string][]string{
+				"filter[exact:container]": {"api-server"},
+				"exclude[container]":      {"web-server"},
+			},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"api-server"}, result[containerCol+" = ?"])
+				assert.Equal(t, []string{"web-server"}, result[containerCol+" != ?"])
+			},
+		},
+		{
+			name:        "workload exact match",
+			queryParams: map[string][]string{"filter[exact:workload]": {"my-deploy"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"my-deploy"}, result[workloadCol+" = ?"])
+			},
+		},
+		{
+			name:        "workload exclude",
+			queryParams: map[string][]string{"exclude[workload]": {"my-deploy"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"my-deploy"}, result[workloadCol+" != ?"])
+			},
+		},
+		{
+			name:        "workload_type exact match",
+			queryParams: map[string][]string{"filter[exact:workload_type]": {"Deployment"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"Deployment"}, result[workloadTypeCol+" = ?"])
+			},
+		},
+		{
+			name:        "workload_type exclude",
+			queryParams: map[string][]string{"exclude[workload_type]": {"DaemonSet"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"DaemonSet"}, result[workloadTypeCol+" != ?"])
+			},
+		},
+		{
+			name:        "project exact match",
+			queryParams: map[string][]string{"filter[exact:project]": {"default"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"default"}, result[projectContainerCol+" = ?"])
+			},
+		},
+		{
+			name:        "project exclude",
+			queryParams: map[string][]string{"exclude[project]": {"kube-system"}},
+			checkResult: func(t *testing.T, result map[string]interface{}) {
+				assert.Equal(t, []string{"kube-system"}, result[projectContainerCol+" != ?"])
+			},
+		},
+		{
+			name:        "exclude and exact same container value - error",
+			queryParams: map[string][]string{"exclude[container]": {"web"}, "filter[exact:container]": {"web"}},
+			wantErr:     true,
+			errContains: "exclude and exact cannot share values",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			rec := httptest.NewRecorder()
+			c := e.NewContext(req, rec)
+			for k, vals := range tt.queryParams {
+				for _, v := range vals {
+					c.QueryParams().Add(k, v)
+				}
+			}
+			result, err := MapQueryParameters(c)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+				return
+			}
+			assert.NoError(t, err)
+			if tt.checkResult != nil {
+				tt.checkResult(t, result)
+			}
+		})
+	}
+}
+
 var FlattenedCSVHeaderFixture = []string{
 	"id",
 	"cluster_uuid",

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -148,17 +148,23 @@ func TestMapQueryParametersFilterClauses(t *testing.T) {
 		},
 		{
 			name:        "workload_type exact match",
-			queryParams: map[string][]string{"filter[exact:workload_type]": {"Deployment"}},
+			queryParams: map[string][]string{"filter[exact:workload_type]": {"deployment"}},
 			checkResult: func(t *testing.T, result map[string]interface{}) {
-				assert.Equal(t, []string{"Deployment"}, result[workloadTypeCol+" = ?"])
+				assert.Equal(t, []string{"deployment"}, result[workloadTypeCol+" = ?"])
 			},
 		},
 		{
 			name:        "workload_type exclude",
-			queryParams: map[string][]string{"exclude[workload_type]": {"DaemonSet"}},
+			queryParams: map[string][]string{"exclude[workload_type]": {"daemonset"}},
 			checkResult: func(t *testing.T, result map[string]interface{}) {
-				assert.Equal(t, []string{"DaemonSet"}, result[workloadTypeCol+" != ?"])
+				assert.Equal(t, []string{"daemonset"}, result[workloadTypeCol+" != ?"])
 			},
+		},
+		{
+			name:        "workload_type invalid value returns error",
+			queryParams: map[string][]string{"workload_type": {"not-a-real-type"}},
+			wantErr:     true,
+			errContains: "invalid workload_type",
 		},
 		{
 			name:        "project exact match",

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -25,6 +25,25 @@ const (
 	FilterModeExclude = "exclude"
 )
 
+// validWorkloadTypes is the fixed set of allowed workload_type values (mirrors the sorted_workloadtype DB enum).
+var validWorkloadTypes = map[string]bool{
+	"daemonset":             true,
+	"deployment":            true,
+	"deploymentconfig":      true,
+	"replicaset":            true,
+	"replicationcontroller": true,
+	"statefulset":           true,
+}
+
+func validateWorkloadTypeValues(vals []string) error {
+	for _, v := range vals {
+		if !validWorkloadTypes[v] {
+			return namespaceAPIErrf(true, "invalid workload_type %q, must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset", v)
+		}
+	}
+	return nil
+}
+
 // FilterModeClause maps mode to SQL clause suffix, wrap for include, and join for multi-value params.
 var FilterModeClause = map[string]struct {
 	Suffix string

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -120,7 +120,13 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, true); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false, true); err != nil {
+	workloadTypeVals := append(
+		c.QueryParams()["workload_type"],
+		append(c.QueryParams()["filter[exact:workload_type]"], c.QueryParams()["exclude[workload_type]"]...)...,
+	)
+	if err := validateWorkloadTypeValues(workloadTypeVals); err != nil {
+		errs = append(errs, err)
+	} else if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false, true); err != nil {
 		errs = append(errs, err)
 	}
 	if err := applyParamFilter(c, queryParams, "container", "recommendation_sets.container_name", model.NamespaceMaxLen, false); err != nil {

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -120,9 +120,10 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, true); err != nil {
 		errs = append(errs, err)
 	}
-	workloadTypeVals := append(
+	workloadTypeVals := slices.Concat(
 		c.QueryParams()["workload_type"],
-		append(c.QueryParams()["filter[exact:workload_type]"], c.QueryParams()["exclude[workload_type]"]...)...,
+		c.QueryParams()["filter[exact:workload_type]"],
+		c.QueryParams()["exclude[workload_type]"],
 	)
 	if err := validateWorkloadTypeValues(workloadTypeVals); err != nil {
 		errs = append(errs, err)

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -77,7 +77,6 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	log := logging.GetLogger()
 	queryParams := make(map[string]interface{})
 	var startTimestamp, endTimestamp time.Time
-	var clusters, projects, workloadNames, workloadTypes, containers []string
 
 	now := time.Now().UTC().Truncate(time.Second)
 	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
@@ -111,81 +110,27 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	}
 	queryParams["recommendation_sets.monitoring_end_time < ?"] = endTimestamp
 
-	clusters = c.QueryParams()["cluster"]
-	if len(clusters) > 0 {
-		paramString, values := parseQueryParams("cluster", clusters)
-		queryParams[paramString] = values
+	var errs []error
+	if err := applyParamFilter(c, queryParams, "cluster", "", model.ClusterMaxLen, true); err != nil {
+		errs = append(errs, err)
 	}
-
-	projects = c.QueryParams()["project"]
-	if len(projects) > 0 {
-		paramString, values := parseQueryParams("project", projects)
-		queryParams[paramString] = values
+	if err := applyParamFilter(c, queryParams, "project", "workloads.namespace", model.NamespaceMaxLen, false); err != nil {
+		errs = append(errs, err)
 	}
-
-	workloadNames = c.QueryParams()["workload"]
-	if len(workloadNames) > 0 {
-		paramString, values := parseQueryParams("workload", workloadNames)
-		queryParams[paramString] = values
+	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, false); err != nil {
+		errs = append(errs, err)
 	}
-
-	workloadTypes = c.QueryParams()["workload_type"]
-	if len(workloadTypes) > 0 {
-		paramString, values := parseQueryParams("workload_type", workloadTypes)
-		queryParams[paramString] = values
+	if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false); err != nil {
+		errs = append(errs, err)
 	}
-
-	containers = c.QueryParams()["container"]
-	if len(containers) > 0 {
-		paramString, values := parseQueryParams("container", containers)
-		queryParams[paramString] = values
+	if err := applyParamFilter(c, queryParams, "container", "recommendation_sets.container_name", model.NamespaceMaxLen, false); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return queryParams, errors.Join(errs...)
 	}
 
 	return queryParams, nil
-}
-
-func parseQueryParams(param string, values []string) (string, []string) {
-	parsedKeyMultipleVal := ""
-	valuesSlice := []string{}
-
-	paramMap := map[string]string{
-		"cluster":       "clusters.cluster_alias ILIKE ?",
-		"workload_type": "workloads.workload_type = ?",
-		"workload":      "workloads.workload_name ILIKE ?",
-		"project":       "workloads.namespace ILIKE ?",
-		"container":     "recommendation_sets.container_name ILIKE ?",
-	}
-
-	if len(values) > 1 {
-		for _, value := range values {
-			if param == "cluster" {
-				parsedKeyMultipleVal = parsedKeyMultipleVal + paramMap[param] + " OR " + "clusters.cluster_uuid ILIKE ?" + " OR "
-				valuesSlice = append(valuesSlice, "%"+value+"%")
-				valuesSlice = append(valuesSlice, "%"+value+"%")
-			} else {
-				parsedKeyMultipleVal = parsedKeyMultipleVal + paramMap[param] + " OR "
-				if param == "workload_type" {
-					valuesSlice = append(valuesSlice, value)
-				} else {
-					valuesSlice = append(valuesSlice, "%"+value+"%")
-				}
-			}
-		}
-		parsedKeyMultipleVal = strings.TrimSuffix(parsedKeyMultipleVal, " OR ")
-		return parsedKeyMultipleVal, valuesSlice
-	} else {
-		switch param {
-		case "cluster":
-			paramMap[param] = paramMap[param] + " OR " + "clusters.cluster_uuid ILIKE ?"
-			valuesSlice = append(valuesSlice, "%"+values[0]+"%")
-			valuesSlice = append(valuesSlice, "%"+values[0]+"%")
-		case "workload_type":
-			valuesSlice = append(valuesSlice, values[0])
-		default:
-			valuesSlice = append(valuesSlice, "%"+values[0]+"%")
-		}
-		return paramMap[param], valuesSlice
-	}
 }
 
 func ParseUnitParams(c echo.Context, defaultCPU, defaultMemory string) (map[string]string, bool, error) {

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -117,10 +117,10 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	if err := applyParamFilter(c, queryParams, "project", "workloads.namespace", model.NamespaceMaxLen, false); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, false); err != nil {
+	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, true); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false); err != nil {
+	if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false, true); err != nil {
 		errs = append(errs, err)
 	}
 	if err := applyParamFilter(c, queryParams, "container", "recommendation_sets.container_name", model.NamespaceMaxLen, false); err != nil {
@@ -353,14 +353,19 @@ func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeV
 	return clauseMap, nil
 }
 
-func applyParamFilter(c echo.Context, queryParams map[string]any, param, column string, maxLen int, allowDot bool) error {
+func applyParamFilter(c echo.Context, queryParams map[string]any, param, column string, maxLen int, allowDot bool, treatIncludeAsExact ...bool) error {
 	cfg := config.GetConfig()
 	excludeKey := "exclude[" + param + "]"
 	exactKey := "filter[exact:" + param + "]"
+	useExactForInclude := len(treatIncludeAsExact) > 0 && treatIncludeAsExact[0]
 	var includeVals, excludeVals, exactVals []string
 	for _, v := range c.QueryParams()[param] {
 		if v != "" {
-			includeVals = append(includeVals, v)
+			if useExactForInclude {
+				exactVals = append(exactVals, v)
+			} else {
+				includeVals = append(includeVals, v)
+			}
 		}
 	}
 

--- a/openapi.json
+++ b/openapi.json
@@ -37,7 +37,25 @@
           {
             "name": "cluster",
             "in": "query",
-            "description": "Cluster alias or UUID",
+            "description": "Partial match on cluster alias, exact match on cluster UUID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude[cluster]",
+            "in": "query",
+            "description": "Exclude cluster by alias or UUID",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[exact:cluster]",
+            "in": "query",
+            "description": "Exact match on cluster alias or UUID",
             "required": false,
             "schema": {
               "type": "string"
@@ -53,9 +71,45 @@
             }
           },
           {
+            "name": "exclude[workload_type]",
+            "in": "query",
+            "description": "Exclude by workload type",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[exact:workload_type]",
+            "in": "query",
+            "description": "Exact match on workload type",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "workload",
             "in": "query",
-            "description": "Workload name",
+            "description": "Partial match on workload name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude[workload]",
+            "in": "query",
+            "description": "Exclude by workload name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[exact:workload]",
+            "in": "query",
+            "description": "Exact match on workload name",
             "required": false,
             "schema": {
               "type": "string"
@@ -64,7 +118,25 @@
           {
             "name": "container",
             "in": "query",
-            "description": "Container name",
+            "description": "Partial match on container name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude[container]",
+            "in": "query",
+            "description": "Exclude by container name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[exact:container]",
+            "in": "query",
+            "description": "Exact match on container name",
             "required": false,
             "schema": {
               "type": "string"
@@ -73,7 +145,25 @@
           {
             "name": "project",
             "in": "query",
-            "description": "Project name",
+            "description": "Partial match on project name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude[project]",
+            "in": "query",
+            "description": "Exclude by project name",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "filter[exact:project]",
+            "in": "query",
+            "description": "Exact match on project name",
             "required": false,
             "schema": {
               "type": "string"

--- a/openapi.json
+++ b/openapi.json
@@ -73,7 +73,7 @@
           {
             "name": "exclude[workload_type]",
             "in": "query",
-            "description": "Exclude by workload type",
+            "description": "Exclude by workload type. Must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset",
             "required": false,
             "schema": {
               "type": "string"
@@ -82,7 +82,7 @@
           {
             "name": "filter[exact:workload_type]",
             "in": "query",
-            "description": "Exact match on workload type",
+            "description": "Exact match on workload type. Must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset",
             "required": false,
             "schema": {
               "type": "string"
@@ -276,6 +276,26 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/RecommendationList"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request, e.g. invalid query parameter value",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "example": "error"
+                    },
+                    "message": {
+                      "type": "string",
+                      "example": "invalid workload_type \"not-a-real-type\", must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset"
+                    }
+                  }
                 }
               }
             }

--- a/openapi.json
+++ b/openapi.json
@@ -64,7 +64,7 @@
           {
             "name": "workload_type",
             "in": "query",
-            "description": "Options are daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset",
+            "description": "Exact match on workload type. Options are daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset",
             "required": false,
             "schema": {
               "type": "string"


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves [RHINENG-21007](https://redhat.atlassian.net/browse/RHINENG-21007)

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [X] New Feature
- [ ] Refactor
- [X] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

[RHINENG-21007]: https://redhat.atlassian.net/browse/RHINENG-21007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Add support for exact and exclusion-based filters in query parameter mapping for list APIs and refactor parameter handling to use a unified filtering helper.

New Features:
- Enable exact-match filters (filter[exact:*]) and exclusion filters (exclude[*]) for container, workload, workload_type, project, and cluster query parameters in list APIs.

Enhancements:
- Refactor MapQueryParameters to delegate query parameter handling to a shared applyParamFilter helper and remove the legacy parseQueryParams implementation.

Tests:
- Add comprehensive unit tests validating the new exact and exclusion filter behaviors and conflict handling for query parameter mapping.