### PR TITLE
Fixes #RHINENG-20862 - Add percentage sorting columns for recommendat…

### DIFF
--- a/internal/api/listoptions/list_options.go
+++ b/internal/api/listoptions/list_options.go
@@ -33,6 +33,20 @@ type ListOptions struct {
 // OrderByMap maps allowed JSON keys to DB columns.
 type OrderByMap map[string]string
 
+// SQLOrderByFragment returns the ORDER BY expression for list queries. For DESC it appends
+// NULLS LAST so rows with NULL in nullable sort columns (e.g. variation *_pct) appear last.
+func SQLOrderByFragment(orderByColumnSQL, orderHow string) string {
+	how := strings.ToLower(strings.TrimSpace(orderHow))
+	if how == "" {
+		how = OrderDesc
+	}
+	s := strings.TrimSpace(orderByColumnSQL) + " " + how
+	if how == OrderDesc {
+		s += " NULLS LAST"
+	}
+	return s
+}
+
 // API-specific maps and defaults.
 var ContainerAllowedOrderBy = OrderByMap{
 	"cluster":       "clusters.cluster_alias",

--- a/internal/api/listoptions/list_options.go
+++ b/internal/api/listoptions/list_options.go
@@ -36,12 +36,8 @@ type OrderByMap map[string]string
 // SQLOrderByFragment returns the ORDER BY expression for list queries. For DESC it appends
 // NULLS LAST so rows with NULL in nullable sort columns (e.g. variation *_pct) appear last.
 func SQLOrderByFragment(orderByColumnSQL, orderHow string) string {
-	how := strings.ToLower(strings.TrimSpace(orderHow))
-	if how == "" {
-		how = OrderDesc
-	}
-	s := strings.TrimSpace(orderByColumnSQL) + " " + how
-	if how == OrderDesc {
+	s := orderByColumnSQL + " " + orderHow
+	if orderHow == OrderDesc {
 		s += " NULLS LAST"
 	}
 	return s

--- a/internal/api/listoptions/list_options_test.go
+++ b/internal/api/listoptions/list_options_test.go
@@ -1,0 +1,48 @@
+package listoptions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLOrderByFragment(t *testing.T) {
+	tests := []struct {
+		name     string
+		column   string
+		orderHow string
+		want     string
+	}{
+		{
+			name:     "container column desc appends NULLS LAST",
+			column:   ContainerAllowedOrderBy["container"],
+			orderHow: OrderDesc,
+			want:     "recommendation_sets.container_name desc NULLS LAST",
+		},
+		{
+			name:     "container column asc omits NULLS LAST",
+			column:   ContainerAllowedOrderBy["container"],
+			orderHow: OrderAsc,
+			want:     "recommendation_sets.container_name asc",
+		},
+		{
+			name:     "namespace cpu variation desc appends NULLS LAST",
+			column:   NsAllowedOrderBy["cpu_variation_short_cost"],
+			orderHow: OrderDesc,
+			want:     "namespace_recommendation_sets.cpu_variation_short_cost_pct desc NULLS LAST",
+		},
+		{
+			name:     "namespace cpu variation asc omits NULLS LAST",
+			column:   NsAllowedOrderBy["cpu_variation_short_cost"],
+			orderHow: OrderAsc,
+			want:     "namespace_recommendation_sets.cpu_variation_short_cost_pct asc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SQLOrderByFragment(tt.column, tt.orderHow)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/model/namespace_recommendation_set.go
+++ b/internal/model/namespace_recommendation_set.go
@@ -91,7 +91,7 @@ func (r *NamespaceRecommendationSet) GetNamespaceRecommendationSets(orgID string
 
 	query.Count(&count)
 	// OrderBy/OrderHow come from ListAPIOptions (allowlisted); secondary sort for stable ordering.
-	query = query.Order(opts.OrderBy + " " + opts.OrderHow).Order("namespace_recommendation_sets.id ASC")
+	query = query.Order(listoptions.SQLOrderByFragment(opts.OrderBy, opts.OrderHow)).Order("namespace_recommendation_sets.id ASC")
 
 	limit := opts.Limit
 	if opts.Format == "csv" {

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -90,7 +90,7 @@ func (r *RecommendationSet) GetRecommendationSets(orgID string, opts listoptions
 	}
 
 	query.Count(&count)
-	query = query.Order(opts.OrderBy + " " + opts.OrderHow)
+	query = query.Order(listoptions.SQLOrderByFragment(opts.OrderBy, opts.OrderHow))
 
 	limit := opts.Limit
 	if opts.Format == "csv" {

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -90,7 +90,8 @@ func (r *RecommendationSet) GetRecommendationSets(orgID string, opts listoptions
 	}
 
 	query.Count(&count)
-	query = query.Order(listoptions.SQLOrderByFragment(opts.OrderBy, opts.OrderHow))
+	// OrderBy/OrderHow come from ListAPIOptions (allowlisted); secondary sort for stable ordering.
+	query = query.Order(listoptions.SQLOrderByFragment(opts.OrderBy, opts.OrderHow)).Order("recommendation_sets.id ASC")
 
 	limit := opts.Limit
 	if opts.Format == "csv" {

--- a/migrations/000023_recommendation_sets_variation_pct_columns.down.sql
+++ b/migrations/000023_recommendation_sets_variation_pct_columns.down.sql
@@ -1,0 +1,13 @@
+ALTER TABLE recommendation_sets
+    DROP COLUMN IF EXISTS cpu_variation_short_cost_pct,
+    DROP COLUMN IF EXISTS cpu_variation_short_performance_pct,
+    DROP COLUMN IF EXISTS cpu_variation_medium_cost_pct,
+    DROP COLUMN IF EXISTS cpu_variation_medium_performance_pct,
+    DROP COLUMN IF EXISTS cpu_variation_long_cost_pct,
+    DROP COLUMN IF EXISTS cpu_variation_long_performance_pct,
+    DROP COLUMN IF EXISTS memory_variation_short_cost_pct,
+    DROP COLUMN IF EXISTS memory_variation_short_performance_pct,
+    DROP COLUMN IF EXISTS memory_variation_medium_cost_pct,
+    DROP COLUMN IF EXISTS memory_variation_medium_performance_pct,
+    DROP COLUMN IF EXISTS memory_variation_long_cost_pct,
+    DROP COLUMN IF EXISTS memory_variation_long_performance_pct;

--- a/migrations/000023_recommendation_sets_variation_pct_columns.up.sql
+++ b/migrations/000023_recommendation_sets_variation_pct_columns.up.sql
@@ -1,0 +1,17 @@
+-- Add per-term, per-engine variation percent-of-request columns for container recommendation_sets sorting
+-- (same names and types as namespace_recommendation_sets.*_pct from 000022).
+-- Existing and new rows keep NULL until the poller fills values; list queries use ORDER BY ... DESC NULLS LAST
+-- so NULLs sort last (see listoptions.SQLOrderByFragment).
+ALTER TABLE recommendation_sets
+    ADD COLUMN cpu_variation_short_cost_pct NUMERIC(10, 4),
+    ADD COLUMN cpu_variation_short_performance_pct NUMERIC(10, 4),
+    ADD COLUMN cpu_variation_medium_cost_pct NUMERIC(10, 4),
+    ADD COLUMN cpu_variation_medium_performance_pct NUMERIC(10, 4),
+    ADD COLUMN cpu_variation_long_cost_pct NUMERIC(10, 4),
+    ADD COLUMN cpu_variation_long_performance_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_short_cost_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_short_performance_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_medium_cost_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_medium_performance_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_long_cost_pct NUMERIC(10, 4),
+    ADD COLUMN memory_variation_long_performance_pct NUMERIC(10, 4);


### PR DESCRIPTION
…ion_sets

## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title
3. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Add sortable percentage variation columns for recommendation set queries and align ordering behavior for nullable sort fields.

New Features:
- Introduce per-term CPU and memory variation percentage columns on recommendation_sets to support new sorting options.

Bug Fixes:
- Ensure descending sort on nullable recommendation set fields places NULL values last for stable, intuitive ordering.

Enhancements:
- Centralize SQL ORDER BY fragment construction in a shared helper used by recommendation set list queries.