### PR TITLE
Fixes #RHINENG-20861 - variation API changes for container and namespace

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -53,6 +53,7 @@ func GetRecommendationSetList(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			recommendationSets[i].Recommendations,
+			&recommendationSets[i].StoredVariationPcts,
 		)
 	}
 
@@ -122,7 +123,9 @@ func GetRecommendationSet(c echo.Context) error {
 			recommendationSet.ClusterUUID,
 			unitChoices,
 			setk8sUnits,
-			recommendationSet.Recommendations)
+			recommendationSet.Recommendations,
+			nil, // single-item fetch: recompute variation percentages from JSON
+		)
 		return c.JSON(http.StatusOK, recommendationSet)
 	} else {
 		return c.JSON(http.StatusNotFound, echo.Map{"status": "not_found", "message": "recommendation not found"})
@@ -175,6 +178,7 @@ func GetNamespaceRecommendationSetList(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			namespaceRecommendationSets[i].Recommendations,
+			&namespaceRecommendationSets[i].StoredVariationPcts,
 		)
 	}
 
@@ -232,7 +236,9 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 			nsRecommendationSet.ClusterUUID,
 			unitChoices,
 			setk8sUnits,
-			nsRecommendationSet.Recommendations)
+			nsRecommendationSet.Recommendations,
+			nil, // single-item fetch: recompute variation percentages from JSON
+		)
 		return c.JSON(http.StatusOK, nsRecommendationSet)
 	} else {
 		return c.JSON(http.StatusNotFound, echo.Map{"status": "not_found", "message": "project recommendation not found"})

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -57,6 +57,7 @@ func GetRecommendationSetList(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			recommendationSets[i].Recommendations,
+			&recommendationSets[i].StoredVariationPcts,
 		)
 	}
 
@@ -126,7 +127,9 @@ func GetRecommendationSet(c echo.Context) error {
 			recommendationSet.ClusterUUID,
 			unitChoices,
 			setk8sUnits,
-			recommendationSet.Recommendations)
+			recommendationSet.Recommendations,
+			nil, // single-item fetch: recompute variation percentages from JSON
+		)
 		return c.JSON(http.StatusOK, recommendationSet)
 	} else {
 		return c.JSON(http.StatusNotFound, echo.Map{"status": "not_found", "message": "recommendation not found"})
@@ -183,6 +186,7 @@ func GetNamespaceRecommendationSetList(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			namespaceRecommendationSets[i].Recommendations,
+			&namespaceRecommendationSets[i].StoredVariationPcts,
 		)
 	}
 
@@ -240,7 +244,9 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 			nsRecommendationSet.ClusterUUID,
 			unitChoices,
 			setk8sUnits,
-			nsRecommendationSet.Recommendations)
+			nsRecommendationSet.Recommendations,
+			nil, // single-item fetch: recompute variation percentages from JSON
+		)
 		return c.JSON(http.StatusOK, nsRecommendationSet)
 	} else {
 		return c.JSON(http.StatusNotFound, echo.Map{"status": "not_found", "message": "project recommendation not found"})

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -128,7 +128,7 @@ func GetRecommendationSet(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			recommendationSet.Recommendations,
-			nil, // single-item fetch: recompute variation percentages from JSON
+			&recommendationSet.StoredVariationPcts,
 		)
 		return c.JSON(http.StatusOK, recommendationSet)
 	} else {
@@ -245,7 +245,7 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 			unitChoices,
 			setk8sUnits,
 			nsRecommendationSet.Recommendations,
-			nil, // single-item fetch: recompute variation percentages from JSON
+			&nsRecommendationSet.StoredVariationPcts,
 		)
 		return c.JSON(http.StatusOK, nsRecommendationSet)
 	} else {

--- a/internal/api/listoptions/list_options.go
+++ b/internal/api/listoptions/list_options.go
@@ -51,6 +51,22 @@ var ContainerAllowedOrderBy = OrderByMap{
 	"project":       "workloads.namespace",
 	"container":     "recommendation_sets.container_name",
 	"last_reported": "clusters.last_reported_at",
+	// Current request amounts
+	"cpu_request_current":    "recommendation_sets.cpu_request_current",
+	"memory_request_current": "recommendation_sets.memory_request_current",
+	// Per-term, per-engine variation (values are percent of current request; DB columns use _pct suffix)
+	"cpu_variation_short_cost":            "recommendation_sets.cpu_variation_short_cost_pct",
+	"cpu_variation_short_performance":     "recommendation_sets.cpu_variation_short_performance_pct",
+	"cpu_variation_medium_cost":           "recommendation_sets.cpu_variation_medium_cost_pct",
+	"cpu_variation_medium_performance":    "recommendation_sets.cpu_variation_medium_performance_pct",
+	"cpu_variation_long_cost":             "recommendation_sets.cpu_variation_long_cost_pct",
+	"cpu_variation_long_performance":      "recommendation_sets.cpu_variation_long_performance_pct",
+	"memory_variation_short_cost":         "recommendation_sets.memory_variation_short_cost_pct",
+	"memory_variation_short_performance":  "recommendation_sets.memory_variation_short_performance_pct",
+	"memory_variation_medium_cost":        "recommendation_sets.memory_variation_medium_cost_pct",
+	"memory_variation_medium_performance": "recommendation_sets.memory_variation_medium_performance_pct",
+	"memory_variation_long_cost":          "recommendation_sets.memory_variation_long_cost_pct",
+	"memory_variation_long_performance":   "recommendation_sets.memory_variation_long_performance_pct",
 }
 
 var NsAllowedOrderBy = OrderByMap{

--- a/internal/api/listoptions/list_options_test.go
+++ b/internal/api/listoptions/list_options_test.go
@@ -49,18 +49,6 @@ func TestSQLOrderByFragment(t *testing.T) {
 			orderHow: OrderDesc,
 			want:     "recommendation_sets.memory_variation_long_performance_pct desc NULLS LAST",
 		},
-		{
-			name:     "namespace cpu variation desc appends NULLS LAST",
-			column:   NsAllowedOrderBy["cpu_variation_short_cost"],
-			orderHow: OrderDesc,
-			want:     "namespace_recommendation_sets.cpu_variation_short_cost_pct desc NULLS LAST",
-		},
-		{
-			name:     "namespace cpu variation asc omits NULLS LAST",
-			column:   NsAllowedOrderBy["cpu_variation_short_cost"],
-			orderHow: OrderAsc,
-			want:     "namespace_recommendation_sets.cpu_variation_short_cost_pct asc",
-		},
 	}
 
 	for _, tt := range tests {

--- a/internal/api/listoptions/list_options_test.go
+++ b/internal/api/listoptions/list_options_test.go
@@ -26,6 +26,30 @@ func TestSQLOrderByFragment(t *testing.T) {
 			want:     "recommendation_sets.container_name asc",
 		},
 		{
+			name:     "container cpu_request_current desc appends NULLS LAST",
+			column:   ContainerAllowedOrderBy["cpu_request_current"],
+			orderHow: OrderDesc,
+			want:     "recommendation_sets.cpu_request_current desc NULLS LAST",
+		},
+		{
+			name:     "container cpu variation desc appends NULLS LAST",
+			column:   ContainerAllowedOrderBy["cpu_variation_short_cost"],
+			orderHow: OrderDesc,
+			want:     "recommendation_sets.cpu_variation_short_cost_pct desc NULLS LAST",
+		},
+		{
+			name:     "container cpu variation asc omits NULLS LAST",
+			column:   ContainerAllowedOrderBy["cpu_variation_short_cost"],
+			orderHow: OrderAsc,
+			want:     "recommendation_sets.cpu_variation_short_cost_pct asc",
+		},
+		{
+			name:     "container memory variation desc appends NULLS LAST",
+			column:   ContainerAllowedOrderBy["memory_variation_long_performance"],
+			orderHow: OrderDesc,
+			want:     "recommendation_sets.memory_variation_long_performance_pct desc NULLS LAST",
+		},
+		{
 			name:     "namespace cpu variation desc appends NULLS LAST",
 			column:   NsAllowedOrderBy["cpu_variation_short_cost"],
 			orderHow: OrderDesc,

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -747,9 +747,12 @@ func dropBoxPlotsObject(recommendationJSON map[string]interface{}) map[string]in
 	return recommendationJSON
 }
 
-func convertVariationToPercentage(recommendationJSON map[string]interface{}) map[string]interface{} {
+// convertVariationToPercentage replaces variation amounts in the recommendation JSON with
+// percentages relative to the corresponding current amounts. When skipRequests is true the
+// "requests" section is left untouched (used when stored *_pct values have already been
+// injected via injectStoredRequestVariationPct).
+func convertVariationToPercentage(recommendationJSON map[string]interface{}, skipRequests bool) map[string]interface{} {
 	var currentCpuLimits, currentMemoryLimits, currentCpuRequests, currentMemoryRequests float64
-	// Current section of recommendation
 
 	current_config, ok := recommendationJSON["current"].(map[string]interface{})
 	if !ok {
@@ -810,7 +813,12 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}) map
 						continue
 					}
 
-					for _, section := range []string{"limits", "requests"} {
+					sections := []string{"limits", "requests"}
+					if skipRequests {
+						sections = []string{"limits"}
+					}
+
+					for _, section := range sections {
 						sectionObject, ok := recommendationSection[section].(map[string]interface{})
 						if ok {
 							memoryObject, ok := sectionObject["memory"].(map[string]interface{})
@@ -851,7 +859,56 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}) map
 	return recommendationJSON
 }
 
-func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, updateUnitsk8s bool, jsonData datatypes.JSON) map[string]interface{} {
+// injectStoredRequestVariationPct writes the pre-computed *_pct DB column values directly into
+// the variation.requests section of the recommendation JSON, replacing the raw amounts. This
+// avoids recomputing percentages from the JSON blob for the requests section. The limits section
+// is left unchanged and must still be processed by convertVariationToPercentage.
+func injectStoredRequestVariationPct(data map[string]interface{}, pcts *model.StoredVariationPcts) map[string]interface{} {
+	terms, ok := data["recommendation_terms"].(map[string]interface{})
+	if !ok {
+		return data
+	}
+	for _, period := range []string{"short_term", "medium_term", "long_term"} {
+		intervalData, ok := terms[period].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		engines, ok := intervalData["recommendation_engines"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, engineName := range []string{"cost", "performance"} {
+			engine, ok := engines[engineName].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			variation, ok := engine["variation"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			requests, ok := variation["requests"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cpuPct, memPct := pcts.Lookup(period, engineName)
+			if cpu, ok := requests["cpu"].(map[string]interface{}); ok && cpuPct != nil {
+				cpu["amount"] = *cpuPct
+				cpu["format"] = "percent"
+			}
+			if mem, ok := requests["memory"].(map[string]interface{}); ok && memPct != nil {
+				mem["amount"] = *memPct
+				mem["format"] = "percent"
+			}
+		}
+	}
+	return data
+}
+
+// UpdateRecommendationJSON transforms raw recommendation JSON for API output: unit conversion,
+// notification filtering, and variation-to-percentage conversion.
+// When storedPcts is provided and has values, the requests variation percentages are taken
+// directly from the stored DB columns instead of being recomputed from the JSON blob.
+func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, updateUnitsk8s bool, jsonData datatypes.JSON, storedPcts *model.StoredVariationPcts) map[string]interface{} {
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(jsonData), &data)
 	if err != nil {
@@ -866,7 +923,13 @@ func UpdateRecommendationJSON(handlerName string, recommendationID string, clust
 
 	data = transformComponentUnits(unitsToTransform, updateUnitsk8s, data) // cpu: core values require truncation
 	data = filterNotifications(recommendationID, clusterUUID, data)
-	data = convertVariationToPercentage(data)
+
+	if storedPcts != nil && storedPcts.HasValues() {
+		data = injectStoredRequestVariationPct(data, storedPcts)
+		data = convertVariationToPercentage(data, true) // limits only; requests already injected
+	} else {
+		data = convertVariationToPercentage(data, false)
+	}
 	return data
 }
 

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -750,9 +750,12 @@ func dropBoxPlotsObject(recommendationJSON map[string]interface{}) map[string]in
 	return recommendationJSON
 }
 
-func convertVariationToPercentage(recommendationJSON map[string]interface{}) map[string]interface{} {
+// convertVariationToPercentage replaces variation amounts in the recommendation JSON with
+// percentages relative to the corresponding current amounts. When skipRequests is true the
+// "requests" section is left untouched (used when stored *_pct values have already been
+// injected via injectStoredRequestVariationPct).
+func convertVariationToPercentage(recommendationJSON map[string]interface{}, skipRequests bool) map[string]interface{} {
 	var currentCpuLimits, currentMemoryLimits, currentCpuRequests, currentMemoryRequests float64
-	// Current section of recommendation
 
 	current_config, ok := recommendationJSON["current"].(map[string]interface{})
 	if !ok {
@@ -813,7 +816,12 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}) map
 						continue
 					}
 
-					for _, section := range []string{"limits", "requests"} {
+					sections := []string{"limits", "requests"}
+					if skipRequests {
+						sections = []string{"limits"}
+					}
+
+					for _, section := range sections {
 						sectionObject, ok := recommendationSection[section].(map[string]interface{})
 						if ok {
 							memoryObject, ok := sectionObject["memory"].(map[string]interface{})
@@ -854,7 +862,56 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}) map
 	return recommendationJSON
 }
 
-func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, updateUnitsk8s bool, jsonData datatypes.JSON) map[string]interface{} {
+// injectStoredRequestVariationPct writes the pre-computed *_pct DB column values directly into
+// the variation.requests section of the recommendation JSON, replacing the raw amounts. This
+// avoids recomputing percentages from the JSON blob for the requests section. The limits section
+// is left unchanged and must still be processed by convertVariationToPercentage.
+func injectStoredRequestVariationPct(data map[string]interface{}, pcts *model.StoredVariationPcts) map[string]interface{} {
+	terms, ok := data["recommendation_terms"].(map[string]interface{})
+	if !ok {
+		return data
+	}
+	for _, period := range []string{"short_term", "medium_term", "long_term"} {
+		intervalData, ok := terms[period].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		engines, ok := intervalData["recommendation_engines"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		for _, engineName := range []string{"cost", "performance"} {
+			engine, ok := engines[engineName].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			variation, ok := engine["variation"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			requests, ok := variation["requests"].(map[string]interface{})
+			if !ok {
+				continue
+			}
+			cpuPct, memPct := pcts.Lookup(period, engineName)
+			if cpu, ok := requests["cpu"].(map[string]interface{}); ok && cpuPct != nil {
+				cpu["amount"] = *cpuPct
+				cpu["format"] = "percent"
+			}
+			if mem, ok := requests["memory"].(map[string]interface{}); ok && memPct != nil {
+				mem["amount"] = *memPct
+				mem["format"] = "percent"
+			}
+		}
+	}
+	return data
+}
+
+// UpdateRecommendationJSON transforms raw recommendation JSON for API output: unit conversion,
+// notification filtering, and variation-to-percentage conversion.
+// When storedPcts is provided and has values, the requests variation percentages are taken
+// directly from the stored DB columns instead of being recomputed from the JSON blob.
+func UpdateRecommendationJSON(handlerName string, recommendationID string, clusterUUID string, unitsToTransform map[string]string, updateUnitsk8s bool, jsonData datatypes.JSON, storedPcts *model.StoredVariationPcts) map[string]interface{} {
 	var data map[string]interface{}
 	err := json.Unmarshal([]byte(jsonData), &data)
 	if err != nil {
@@ -869,7 +926,13 @@ func UpdateRecommendationJSON(handlerName string, recommendationID string, clust
 
 	data = transformComponentUnits(unitsToTransform, updateUnitsk8s, data) // cpu: core values require truncation
 	data = filterNotifications(recommendationID, clusterUUID, data)
-	data = convertVariationToPercentage(data)
+
+	if storedPcts != nil && storedPcts.HasValues() {
+		data = injectStoredRequestVariationPct(data, storedPcts)
+		data = convertVariationToPercentage(data, true) // limits only; requests already injected
+	} else {
+		data = convertVariationToPercentage(data, false)
+	}
 	return data
 }
 

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -924,12 +924,11 @@ func UpdateRecommendationJSON(handlerName string, recommendationID string, clust
 	data = transformComponentUnits(unitsToTransform, updateUnitsk8s, data) // cpu: core values require truncation
 	data = filterNotifications(recommendationID, clusterUUID, data)
 
-	if storedPcts != nil && storedPcts.HasValues() {
+	skipRequests := storedPcts != nil && storedPcts.HasValues()
+	if skipRequests {
 		data = injectStoredRequestVariationPct(data, storedPcts)
-		data = convertVariationToPercentage(data, true) // limits only; requests already injected
-	} else {
-		data = convertVariationToPercentage(data, false)
 	}
+	data = convertVariationToPercentage(data, skipRequests)
 	return data
 }
 

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -1,12 +1,15 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/redhatinsights/ros-ocp-backend/internal/model"
 	"gorm.io/datatypes"
 )
+
+func float64Ptr(v float64) *float64 { return &v }
 
 // Minimal recommendation JSON that exercises both term and engine maps.
 // short_term has cost + performance engines; medium_term has cost only.
@@ -121,4 +124,77 @@ func TestGenerateCSVRows_TermOrdering(t *testing.T) {
 				i, rows[i][18], rows[i][21], exp[0], exp[1])
 		}
 	}
+}
+
+// injectTestJSON is minimal: one term/engine with variation limits + requests (raw units before inject).
+const injectTestJSON = `{
+	"recommendation_terms": {
+		"short_term": {
+			"recommendation_engines": {
+				"cost": {
+					"variation": {
+						"limits": {"cpu": {"amount": -1.0, "format": "cores"}},
+						"requests": {"cpu": {"amount": 0.1, "format": "cores"}, "memory": {"amount": 512, "format": "bytes"}}
+					}
+				}
+			}
+		}
+	}
+}`
+
+func TestInjectStoredRequestVariationPct(t *testing.T) {
+	t.Run("writes requests from stored pcts and sets format percent", func(t *testing.T) {
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(injectTestJSON), &data); err != nil {
+			t.Fatal(err)
+		}
+		pcts := &model.StoredVariationPcts{
+			CPUVariationShortCostPct:    float64Ptr(12.5),
+			MemoryVariationShortCostPct: float64Ptr(3.25),
+		}
+		out := injectStoredRequestVariationPct(data, pcts)
+		v := out["recommendation_terms"].(map[string]interface{})["short_term"].(map[string]interface{})["recommendation_engines"].(map[string]interface{})["cost"].(map[string]interface{})["variation"].(map[string]interface{})
+		req := v["requests"].(map[string]interface{})
+		lim := v["limits"].(map[string]interface{})
+
+		if got := req["cpu"].(map[string]interface{})["amount"]; got != 12.5 {
+			t.Fatalf("requests.cpu.amount: got %v, want 12.5", got)
+		}
+		if got := req["cpu"].(map[string]interface{})["format"]; got != "percent" {
+			t.Fatalf("requests.cpu.format: got %v, want percent", got)
+		}
+		if got := req["memory"].(map[string]interface{})["amount"]; got != 3.25 {
+			t.Fatalf("requests.memory.amount: got %v, want 3.25", got)
+		}
+		if got := req["memory"].(map[string]interface{})["format"]; got != "percent" {
+			t.Fatalf("requests.memory.format: got %v, want percent", got)
+		}
+		if got := lim["cpu"].(map[string]interface{})["amount"]; got != -1.0 {
+			t.Fatalf("limits.cpu.amount should be unchanged: got %v", got)
+		}
+	})
+
+	t.Run("skips field when stored pointer is nil", func(t *testing.T) {
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(injectTestJSON), &data); err != nil {
+			t.Fatal(err)
+		}
+		pcts := &model.StoredVariationPcts{
+			CPUVariationShortCostPct:    float64Ptr(9.0),
+			MemoryVariationShortCostPct: nil,
+		}
+		out := injectStoredRequestVariationPct(data, pcts)
+		req := out["recommendation_terms"].(map[string]interface{})["short_term"].(map[string]interface{})["recommendation_engines"].(map[string]interface{})["cost"].(map[string]interface{})["variation"].(map[string]interface{})["requests"].(map[string]interface{})
+
+		if got := req["cpu"].(map[string]interface{})["amount"]; got != 9.0 {
+			t.Fatalf("cpu: got %v, want 9", got)
+		}
+		// memory not overwritten
+		if got := req["memory"].(map[string]interface{})["amount"]; got != 512.0 {
+			t.Fatalf("memory amount: got %v, want 512 (unchanged)", got)
+		}
+		if got := req["memory"].(map[string]interface{})["format"]; got != "bytes" {
+			t.Fatalf("memory format: got %v, want bytes", got)
+		}
+	})
 }

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -38,7 +38,7 @@ type RecommendationColumnValues struct {
 }
 
 // ExtractRecommendationColumnValues extracts current requests and per-term, per-engine
-// variation as percent-of-request for namespace_recommendation_sets columns (namespace poller).
+// variation as percent-of-request for recommendation_sets and namespace_recommendation_sets columns.
 func ExtractRecommendationColumnValues(data kruizePayload.RecommendationData) RecommendationColumnValues {
 	recommVals := RecommendationColumnValues{
 		CPURequestCurrent:    data.Current.Requests.Cpu.Amount,

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -15,6 +15,10 @@ const (
 	ClusterMaxLen = 253
 )
 
+func ptrFloat64(v float64) *float64 {
+	return &v
+}
+
 // StoredVariationPcts holds pre-computed per-term, per-engine variation percentages fetched
 // from DB columns. Used in API response building to avoid recomputing from the JSON blob.
 // Fields are pointers to handle nullable DB columns (e.g. existing rows before migration).
@@ -72,57 +76,57 @@ func (s *StoredVariationPcts) Lookup(term, engine string) (cpu, mem *float64) {
 // RecommendationColumnValues holds current request and per-term, per-engine variation
 // as percent of current request. Values match transformComponentUnits + convertVariationToPercentage
 // (CPU cores truncated to 3dp, memory bytes as MiB to 2dp, then percent to 3dp).
+// Pointer fields are nil when a term/engine is absent so GORM persists SQL NULL.
 // Used to populate recommendation_sets and namespace_recommendation_sets columns for sorting.
 type RecommendationColumnValues struct {
-	CPURequestCurrent    float64
-	MemoryRequestCurrent float64
+	CPURequestCurrent    *float64
+	MemoryRequestCurrent *float64
 
-	CPUVariationShortCostPct            float64
-	CPUVariationShortPerformancePct     float64
-	CPUVariationMediumCostPct           float64
-	CPUVariationMediumPerformancePct    float64
-	CPUVariationLongCostPct             float64
-	CPUVariationLongPerformancePct      float64
-	MemoryVariationShortCostPct         float64
-	MemoryVariationShortPerformancePct  float64
-	MemoryVariationMediumCostPct        float64
-	MemoryVariationMediumPerformancePct float64
-	MemoryVariationLongCostPct          float64
-	MemoryVariationLongPerformancePct   float64
+	CPUVariationShortCostPct            *float64
+	CPUVariationShortPerformancePct     *float64
+	CPUVariationMediumCostPct           *float64
+	CPUVariationMediumPerformancePct    *float64
+	CPUVariationLongCostPct             *float64
+	CPUVariationLongPerformancePct      *float64
+	MemoryVariationShortCostPct         *float64
+	MemoryVariationShortPerformancePct  *float64
+	MemoryVariationMediumCostPct        *float64
+	MemoryVariationMediumPerformancePct *float64
+	MemoryVariationLongCostPct          *float64
+	MemoryVariationLongPerformancePct   *float64
 }
 
 // ExtractRecommendationColumnValues extracts current requests and per-term, per-engine
 // variation as percent-of-request for recommendation_sets and namespace_recommendation_sets columns.
 func ExtractRecommendationColumnValues(data kruizePayload.RecommendationData) RecommendationColumnValues {
+	cpuReq := data.Current.Requests.Cpu.Amount
+	memReq := data.Current.Requests.Memory.Amount
 	recommVals := RecommendationColumnValues{
-		CPURequestCurrent:    data.Current.Requests.Cpu.Amount,
-		MemoryRequestCurrent: data.Current.Requests.Memory.Amount,
+		CPURequestCurrent:    ptrFloat64(cpuReq),
+		MemoryRequestCurrent: ptrFloat64(memReq),
 	}
-	extractTermVariations(&recommVals, data.RecommendationTerms)
+	extractTermVariations(&recommVals, data.RecommendationTerms, cpuReq, memReq)
 	return recommVals
 }
 
-func extractTermVariations(recommVals *RecommendationColumnValues, terms kruizePayload.Term) {
-	cpuReq := recommVals.CPURequestCurrent
-	memReq := recommVals.MemoryRequestCurrent
-
+func extractTermVariations(recommVals *RecommendationColumnValues, terms kruizePayload.Term, cpuReq, memReq float64) {
 	if e := terms.Short_term.RecommendationEngines; e != nil {
-		recommVals.CPUVariationShortCostPct = utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationShortCostPct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq)
-		recommVals.CPUVariationShortPerformancePct = utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationShortPerformancePct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq)
+		recommVals.CPUVariationShortCostPct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationShortCostPct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq))
+		recommVals.CPUVariationShortPerformancePct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationShortPerformancePct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq))
 	}
 	if e := terms.Medium_term.RecommendationEngines; e != nil {
-		recommVals.CPUVariationMediumCostPct = utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationMediumCostPct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq)
-		recommVals.CPUVariationMediumPerformancePct = utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationMediumPerformancePct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq)
+		recommVals.CPUVariationMediumCostPct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationMediumCostPct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq))
+		recommVals.CPUVariationMediumPerformancePct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationMediumPerformancePct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq))
 	}
 	if e := terms.Long_term.RecommendationEngines; e != nil {
-		recommVals.CPUVariationLongCostPct = utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationLongCostPct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq)
-		recommVals.CPUVariationLongPerformancePct = utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq)
-		recommVals.MemoryVariationLongPerformancePct = utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq)
+		recommVals.CPUVariationLongCostPct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Cost.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationLongCostPct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Cost.Variation.Requests.Memory.Amount, memReq))
+		recommVals.CPUVariationLongPerformancePct = ptrFloat64(utils.VariationPercentOfRequestCPU(e.Performance.Variation.Requests.Cpu.Amount, cpuReq))
+		recommVals.MemoryVariationLongPerformancePct = ptrFloat64(utils.VariationPercentOfRequestMemoryBytesMiB(e.Performance.Variation.Requests.Memory.Amount, memReq))
 	}
 }
 

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -15,10 +15,64 @@ const (
 	ClusterMaxLen = 253
 )
 
+// StoredVariationPcts holds pre-computed per-term, per-engine variation percentages fetched
+// from DB columns. Used in API response building to avoid recomputing from the JSON blob.
+// Fields are pointers to handle nullable DB columns (e.g. existing rows before migration).
+type StoredVariationPcts struct {
+	CPUVariationShortCostPct            *float64 `gorm:"column:cpu_variation_short_cost_pct" json:"-"`
+	CPUVariationShortPerformancePct     *float64 `gorm:"column:cpu_variation_short_performance_pct" json:"-"`
+	CPUVariationMediumCostPct           *float64 `gorm:"column:cpu_variation_medium_cost_pct" json:"-"`
+	CPUVariationMediumPerformancePct    *float64 `gorm:"column:cpu_variation_medium_performance_pct" json:"-"`
+	CPUVariationLongCostPct             *float64 `gorm:"column:cpu_variation_long_cost_pct" json:"-"`
+	CPUVariationLongPerformancePct      *float64 `gorm:"column:cpu_variation_long_performance_pct" json:"-"`
+	MemoryVariationShortCostPct         *float64 `gorm:"column:memory_variation_short_cost_pct" json:"-"`
+	MemoryVariationShortPerformancePct  *float64 `gorm:"column:memory_variation_short_performance_pct" json:"-"`
+	MemoryVariationMediumCostPct        *float64 `gorm:"column:memory_variation_medium_cost_pct" json:"-"`
+	MemoryVariationMediumPerformancePct *float64 `gorm:"column:memory_variation_medium_performance_pct" json:"-"`
+	MemoryVariationLongCostPct          *float64 `gorm:"column:memory_variation_long_cost_pct" json:"-"`
+	MemoryVariationLongPerformancePct   *float64 `gorm:"column:memory_variation_long_performance_pct" json:"-"`
+}
+
+// HasValues reports whether at least one stored percentage is non-nil.
+func (s *StoredVariationPcts) HasValues() bool {
+	return s.CPUVariationShortCostPct != nil ||
+		s.CPUVariationShortPerformancePct != nil ||
+		s.CPUVariationMediumCostPct != nil ||
+		s.CPUVariationMediumPerformancePct != nil ||
+		s.CPUVariationLongCostPct != nil ||
+		s.CPUVariationLongPerformancePct != nil ||
+		s.MemoryVariationShortCostPct != nil ||
+		s.MemoryVariationShortPerformancePct != nil ||
+		s.MemoryVariationMediumCostPct != nil ||
+		s.MemoryVariationMediumPerformancePct != nil ||
+		s.MemoryVariationLongCostPct != nil ||
+		s.MemoryVariationLongPerformancePct != nil
+}
+
+// Lookup returns the stored CPU and memory variation pct for a given term (e.g. "short_term") and
+// engine name (e.g. "cost"). Returns (nil, nil) when the combination is not recognised.
+func (s *StoredVariationPcts) Lookup(term, engine string) (cpu, mem *float64) {
+	switch {
+	case term == "short_term" && engine == "cost":
+		return s.CPUVariationShortCostPct, s.MemoryVariationShortCostPct
+	case term == "short_term" && engine == "performance":
+		return s.CPUVariationShortPerformancePct, s.MemoryVariationShortPerformancePct
+	case term == "medium_term" && engine == "cost":
+		return s.CPUVariationMediumCostPct, s.MemoryVariationMediumCostPct
+	case term == "medium_term" && engine == "performance":
+		return s.CPUVariationMediumPerformancePct, s.MemoryVariationMediumPerformancePct
+	case term == "long_term" && engine == "cost":
+		return s.CPUVariationLongCostPct, s.MemoryVariationLongCostPct
+	case term == "long_term" && engine == "performance":
+		return s.CPUVariationLongPerformancePct, s.MemoryVariationLongPerformancePct
+	}
+	return nil, nil
+}
+
 // RecommendationColumnValues holds current request and per-term, per-engine variation
 // as percent of current request. Values match transformComponentUnits + convertVariationToPercentage
 // (CPU cores truncated to 3dp, memory bytes as MiB to 2dp, then percent to 3dp).
-// Used to populate namespace_recommendation_sets columns for sorting aligned with API display.
+// Used to populate recommendation_sets and namespace_recommendation_sets columns for sorting.
 type RecommendationColumnValues struct {
 	CPURequestCurrent    float64
 	MemoryRequestCurrent float64
@@ -84,7 +138,19 @@ func getRecommendationQuery(orgID string) *gorm.DB {
 			"clusters.cluster_uuid, "+
 			"clusters.cluster_alias, "+
 			"clusters.last_reported_at AS last_reported, "+
-			"recommendation_sets.recommendations").
+			"recommendation_sets.recommendations, "+
+			"recommendation_sets.cpu_variation_short_cost_pct, "+
+			"recommendation_sets.cpu_variation_short_performance_pct, "+
+			"recommendation_sets.cpu_variation_medium_cost_pct, "+
+			"recommendation_sets.cpu_variation_medium_performance_pct, "+
+			"recommendation_sets.cpu_variation_long_cost_pct, "+
+			"recommendation_sets.cpu_variation_long_performance_pct, "+
+			"recommendation_sets.memory_variation_short_cost_pct, "+
+			"recommendation_sets.memory_variation_short_performance_pct, "+
+			"recommendation_sets.memory_variation_medium_cost_pct, "+
+			"recommendation_sets.memory_variation_medium_performance_pct, "+
+			"recommendation_sets.memory_variation_long_cost_pct, "+
+			"recommendation_sets.memory_variation_long_performance_pct").
 		Joins(`
 			JOIN workloads ON recommendation_sets.workload_id = workloads.id
 			JOIN clusters ON workloads.cluster_id = clusters.id
@@ -103,7 +169,19 @@ func getNamespaceRecommendationQuery(orgID string) *gorm.DB {
 			"clusters.cluster_uuid, "+
 			"clusters.cluster_alias, "+
 			"clusters.last_reported_at AS last_reported, "+
-			"namespace_recommendation_sets.recommendations").
+			"namespace_recommendation_sets.recommendations, "+
+			"namespace_recommendation_sets.cpu_variation_short_cost_pct, "+
+			"namespace_recommendation_sets.cpu_variation_short_performance_pct, "+
+			"namespace_recommendation_sets.cpu_variation_medium_cost_pct, "+
+			"namespace_recommendation_sets.cpu_variation_medium_performance_pct, "+
+			"namespace_recommendation_sets.cpu_variation_long_cost_pct, "+
+			"namespace_recommendation_sets.cpu_variation_long_performance_pct, "+
+			"namespace_recommendation_sets.memory_variation_short_cost_pct, "+
+			"namespace_recommendation_sets.memory_variation_short_performance_pct, "+
+			"namespace_recommendation_sets.memory_variation_medium_cost_pct, "+
+			"namespace_recommendation_sets.memory_variation_medium_performance_pct, "+
+			"namespace_recommendation_sets.memory_variation_long_cost_pct, "+
+			"namespace_recommendation_sets.memory_variation_long_performance_pct").
 		Joins(`
 			JOIN workloads ON namespace_recommendation_sets.workload_id = workloads.id
 			JOIN clusters ON workloads.cluster_id = clusters.id

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -104,8 +104,8 @@ func ExtractRecommendationColumnValues(data kruizePayload.RecommendationData) Re
 
 	// Clamp current request values to the backing DB numeric ranges to prevent insert/update failures.
 	// cpu_request_current is NUMERIC(10,4); memory_request_current is NUMERIC(20,4).
-	cpuReq = utils.ClampToNumeric10_4(cpuReq)
-	memReq = utils.ClampToNumeric20_4(memReq)
+	cpuReq = utils.ClampToNumeric10_4Range(cpuReq)
+	memReq = utils.ClampToNumeric20_4Range(memReq)
 	recommVals := RecommendationColumnValues{
 		CPURequestCurrent:    ptrFloat64(cpuReq),
 		MemoryRequestCurrent: ptrFloat64(memReq),

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -101,6 +101,11 @@ type RecommendationColumnValues struct {
 func ExtractRecommendationColumnValues(data kruizePayload.RecommendationData) RecommendationColumnValues {
 	cpuReq := data.Current.Requests.Cpu.Amount
 	memReq := data.Current.Requests.Memory.Amount
+
+	// Clamp current request values to the backing DB numeric ranges to prevent insert/update failures.
+	// cpu_request_current is NUMERIC(10,4); memory_request_current is NUMERIC(20,4).
+	cpuReq = utils.ClampToNumeric10_4(cpuReq)
+	memReq = utils.ClampToNumeric20_4(memReq)
 	recommVals := RecommendationColumnValues{
 		CPURequestCurrent:    ptrFloat64(cpuReq),
 		MemoryRequestCurrent: ptrFloat64(memReq),

--- a/internal/model/namespace_recommendation_set.go
+++ b/internal/model/namespace_recommendation_set.go
@@ -20,22 +20,22 @@ type NamespaceRecommendationSet struct {
 	WorkloadID           uint
 	Workload             Workload `gorm:"foreignKey:WorkloadID"`
 	NamespaceName        string
-	CPURequestCurrent    float64
-	MemoryRequestCurrent float64
+	CPURequestCurrent    *float64
+	MemoryRequestCurrent *float64
 
 	// Variation fields: percent of current CPU/memory request (aligned with API response).
-	CPUVariationShortCostPct            float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`
-	CPUVariationShortPerformancePct     float64 `gorm:"column:cpu_variation_short_performance_pct;type:numeric(10,4)"`
-	CPUVariationMediumCostPct           float64 `gorm:"column:cpu_variation_medium_cost_pct;type:numeric(10,4)"`
-	CPUVariationMediumPerformancePct    float64 `gorm:"column:cpu_variation_medium_performance_pct;type:numeric(10,4)"`
-	CPUVariationLongCostPct             float64 `gorm:"column:cpu_variation_long_cost_pct;type:numeric(10,4)"`
-	CPUVariationLongPerformancePct      float64 `gorm:"column:cpu_variation_long_performance_pct;type:numeric(10,4)"`
-	MemoryVariationShortCostPct         float64 `gorm:"column:memory_variation_short_cost_pct;type:numeric(10,4)"`
-	MemoryVariationShortPerformancePct  float64 `gorm:"column:memory_variation_short_performance_pct;type:numeric(10,4)"`
-	MemoryVariationMediumCostPct        float64 `gorm:"column:memory_variation_medium_cost_pct;type:numeric(10,4)"`
-	MemoryVariationMediumPerformancePct float64 `gorm:"column:memory_variation_medium_performance_pct;type:numeric(10,4)"`
-	MemoryVariationLongCostPct          float64 `gorm:"column:memory_variation_long_cost_pct;type:numeric(10,4)"`
-	MemoryVariationLongPerformancePct   float64 `gorm:"column:memory_variation_long_performance_pct;type:numeric(10,4)"`
+	CPUVariationShortCostPct            *float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`
+	CPUVariationShortPerformancePct     *float64 `gorm:"column:cpu_variation_short_performance_pct;type:numeric(10,4)"`
+	CPUVariationMediumCostPct           *float64 `gorm:"column:cpu_variation_medium_cost_pct;type:numeric(10,4)"`
+	CPUVariationMediumPerformancePct    *float64 `gorm:"column:cpu_variation_medium_performance_pct;type:numeric(10,4)"`
+	CPUVariationLongCostPct             *float64 `gorm:"column:cpu_variation_long_cost_pct;type:numeric(10,4)"`
+	CPUVariationLongPerformancePct      *float64 `gorm:"column:cpu_variation_long_performance_pct;type:numeric(10,4)"`
+	MemoryVariationShortCostPct         *float64 `gorm:"column:memory_variation_short_cost_pct;type:numeric(10,4)"`
+	MemoryVariationShortPerformancePct  *float64 `gorm:"column:memory_variation_short_performance_pct;type:numeric(10,4)"`
+	MemoryVariationMediumCostPct        *float64 `gorm:"column:memory_variation_medium_cost_pct;type:numeric(10,4)"`
+	MemoryVariationMediumPerformancePct *float64 `gorm:"column:memory_variation_medium_performance_pct;type:numeric(10,4)"`
+	MemoryVariationLongCostPct          *float64 `gorm:"column:memory_variation_long_cost_pct;type:numeric(10,4)"`
+	MemoryVariationLongPerformancePct   *float64 `gorm:"column:memory_variation_long_performance_pct;type:numeric(10,4)"`
 
 	MonitoringStartTime    time.Time `gorm:"type:timestamp"`
 	MonitoringEndTime      time.Time `gorm:"type:timestamp"`

--- a/internal/model/namespace_recommendation_set.go
+++ b/internal/model/namespace_recommendation_set.go
@@ -56,6 +56,8 @@ type NamespaceRecommendationSetResult struct {
 	Recommendations     datatypes.JSON `json:"-"`
 	RecommendationsJSON map[string]any `gorm:"-" json:"recommendations"`
 	SourceID            string         `json:"source_id"`
+	// Embedded stored variation percentages (scanned from SELECT, excluded from JSON output).
+	StoredVariationPcts `gorm:"embedded"`
 }
 
 func (r *NamespaceRecommendationSet) AfterFind(tx *gorm.DB) error {

--- a/internal/model/namespace_recommendation_set.go
+++ b/internal/model/namespace_recommendation_set.go
@@ -20,8 +20,8 @@ type NamespaceRecommendationSet struct {
 	WorkloadID           uint
 	Workload             Workload `gorm:"foreignKey:WorkloadID"`
 	NamespaceName        string
-	CPURequestCurrent    *float64
-	MemoryRequestCurrent *float64
+	CPURequestCurrent    *float64 `gorm:"column:cpu_request_current;type:numeric(10,4)"`
+	MemoryRequestCurrent *float64 `gorm:"column:memory_request_current;type:numeric(20,4)"`
 
 	// Variation fields: percent of current CPU/memory request (aligned with API response).
 	CPUVariationShortCostPct            *float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -20,22 +20,22 @@ type RecommendationSet struct {
 	Workload      Workload `gorm:"foreignKey:WorkloadID"`
 	ContainerName string
 
-	CPURequestCurrent    float64
-	MemoryRequestCurrent float64
+	CPURequestCurrent    *float64
+	MemoryRequestCurrent *float64
 
 	// Variation fields: percent of current CPU/memory request (aligned with API response).
-	CPUVariationShortCostPct            float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`
-	CPUVariationShortPerformancePct     float64 `gorm:"column:cpu_variation_short_performance_pct;type:numeric(10,4)"`
-	CPUVariationMediumCostPct           float64 `gorm:"column:cpu_variation_medium_cost_pct;type:numeric(10,4)"`
-	CPUVariationMediumPerformancePct    float64 `gorm:"column:cpu_variation_medium_performance_pct;type:numeric(10,4)"`
-	CPUVariationLongCostPct             float64 `gorm:"column:cpu_variation_long_cost_pct;type:numeric(10,4)"`
-	CPUVariationLongPerformancePct      float64 `gorm:"column:cpu_variation_long_performance_pct;type:numeric(10,4)"`
-	MemoryVariationShortCostPct         float64 `gorm:"column:memory_variation_short_cost_pct;type:numeric(10,4)"`
-	MemoryVariationShortPerformancePct  float64 `gorm:"column:memory_variation_short_performance_pct;type:numeric(10,4)"`
-	MemoryVariationMediumCostPct        float64 `gorm:"column:memory_variation_medium_cost_pct;type:numeric(10,4)"`
-	MemoryVariationMediumPerformancePct float64 `gorm:"column:memory_variation_medium_performance_pct;type:numeric(10,4)"`
-	MemoryVariationLongCostPct          float64 `gorm:"column:memory_variation_long_cost_pct;type:numeric(10,4)"`
-	MemoryVariationLongPerformancePct   float64 `gorm:"column:memory_variation_long_performance_pct;type:numeric(10,4)"`
+	CPUVariationShortCostPct            *float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`
+	CPUVariationShortPerformancePct     *float64 `gorm:"column:cpu_variation_short_performance_pct;type:numeric(10,4)"`
+	CPUVariationMediumCostPct           *float64 `gorm:"column:cpu_variation_medium_cost_pct;type:numeric(10,4)"`
+	CPUVariationMediumPerformancePct    *float64 `gorm:"column:cpu_variation_medium_performance_pct;type:numeric(10,4)"`
+	CPUVariationLongCostPct             *float64 `gorm:"column:cpu_variation_long_cost_pct;type:numeric(10,4)"`
+	CPUVariationLongPerformancePct      *float64 `gorm:"column:cpu_variation_long_performance_pct;type:numeric(10,4)"`
+	MemoryVariationShortCostPct         *float64 `gorm:"column:memory_variation_short_cost_pct;type:numeric(10,4)"`
+	MemoryVariationShortPerformancePct  *float64 `gorm:"column:memory_variation_short_performance_pct;type:numeric(10,4)"`
+	MemoryVariationMediumCostPct        *float64 `gorm:"column:memory_variation_medium_cost_pct;type:numeric(10,4)"`
+	MemoryVariationMediumPerformancePct *float64 `gorm:"column:memory_variation_medium_performance_pct;type:numeric(10,4)"`
+	MemoryVariationLongCostPct          *float64 `gorm:"column:memory_variation_long_cost_pct;type:numeric(10,4)"`
+	MemoryVariationLongPerformancePct   *float64 `gorm:"column:memory_variation_long_performance_pct;type:numeric(10,4)"`
 
 	MonitoringStartTime    time.Time `gorm:"type:timestamp"`
 	MonitoringEndTime      time.Time `gorm:"type:timestamp"`

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -48,9 +48,8 @@ type RecommendationSet struct {
 
 type RecommendationSetResult struct {
 	/*
-		Intended to be an API-ready struct
-		Updated recommendation data is saved to RecommendationsJSON
-		Before the API response is sent
+		Intended to be an API-ready struct.
+		Updated recommendation data is saved to RecommendationsJSON before the API response is sent.
 	*/
 	ClusterAlias        string                 `json:"cluster_alias"`
 	ClusterUUID         string                 `json:"cluster_uuid"`
@@ -63,6 +62,8 @@ type RecommendationSetResult struct {
 	SourceID            string                 `json:"source_id"`
 	Workload            string                 `json:"workload"`
 	WorkloadType        string                 `json:"workload_type"`
+	// Embedded stored variation percentages (scanned from SELECT, excluded from JSON output).
+	StoredVariationPcts `gorm:"embedded"`
 }
 
 func (r *RecommendationSet) AfterFind(tx *gorm.DB) error {

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -15,10 +15,28 @@ import (
 )
 
 type RecommendationSet struct {
-	ID                     string `gorm:"primaryKey;not null;autoIncrement"`
-	WorkloadID             uint
-	Workload               Workload `gorm:"foreignKey:WorkloadID"`
-	ContainerName          string
+	ID            string `gorm:"primaryKey;not null;autoIncrement"`
+	WorkloadID    uint
+	Workload      Workload `gorm:"foreignKey:WorkloadID"`
+	ContainerName string
+
+	CPURequestCurrent    float64
+	MemoryRequestCurrent float64
+
+	// Variation fields: percent of current CPU/memory request (aligned with API response).
+	CPUVariationShortCostPct            float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`
+	CPUVariationShortPerformancePct     float64 `gorm:"column:cpu_variation_short_performance_pct;type:numeric(10,4)"`
+	CPUVariationMediumCostPct           float64 `gorm:"column:cpu_variation_medium_cost_pct;type:numeric(10,4)"`
+	CPUVariationMediumPerformancePct    float64 `gorm:"column:cpu_variation_medium_performance_pct;type:numeric(10,4)"`
+	CPUVariationLongCostPct             float64 `gorm:"column:cpu_variation_long_cost_pct;type:numeric(10,4)"`
+	CPUVariationLongPerformancePct      float64 `gorm:"column:cpu_variation_long_performance_pct;type:numeric(10,4)"`
+	MemoryVariationShortCostPct         float64 `gorm:"column:memory_variation_short_cost_pct;type:numeric(10,4)"`
+	MemoryVariationShortPerformancePct  float64 `gorm:"column:memory_variation_short_performance_pct;type:numeric(10,4)"`
+	MemoryVariationMediumCostPct        float64 `gorm:"column:memory_variation_medium_cost_pct;type:numeric(10,4)"`
+	MemoryVariationMediumPerformancePct float64 `gorm:"column:memory_variation_medium_performance_pct;type:numeric(10,4)"`
+	MemoryVariationLongCostPct          float64 `gorm:"column:memory_variation_long_cost_pct;type:numeric(10,4)"`
+	MemoryVariationLongPerformancePct   float64 `gorm:"column:memory_variation_long_performance_pct;type:numeric(10,4)"`
+
 	MonitoringStartTime    time.Time `gorm:"type:timestamp"`
 	MonitoringEndTime      time.Time `gorm:"type:timestamp"`
 	Recommendations        datatypes.JSON
@@ -127,8 +145,27 @@ func (r *RecommendationSet) GetRecommendationSetByID(orgID string, recommendatio
 
 func (r *RecommendationSet) CreateRecommendationSet(tx *gorm.DB) error {
 	result := tx.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "workload_id"}, {Name: "container_name"}},
-		DoUpdates: clause.AssignmentColumns([]string{"monitoring_start_time", "monitoring_end_time", "recommendations", "updated_at"}),
+		Columns: []clause.Column{{Name: "workload_id"}, {Name: "container_name"}},
+		DoUpdates: clause.AssignmentColumns([]string{
+			"monitoring_start_time",
+			"monitoring_end_time",
+			"recommendations",
+			"updated_at",
+			"cpu_request_current",
+			"memory_request_current",
+			"cpu_variation_short_cost_pct",
+			"cpu_variation_short_performance_pct",
+			"cpu_variation_medium_cost_pct",
+			"cpu_variation_medium_performance_pct",
+			"cpu_variation_long_cost_pct",
+			"cpu_variation_long_performance_pct",
+			"memory_variation_short_cost_pct",
+			"memory_variation_short_performance_pct",
+			"memory_variation_medium_cost_pct",
+			"memory_variation_medium_performance_pct",
+			"memory_variation_long_cost_pct",
+			"memory_variation_long_performance_pct",
+		}),
 	}).Create(r)
 
 	if result.Error != nil {

--- a/internal/model/recommendation_set.go
+++ b/internal/model/recommendation_set.go
@@ -20,8 +20,8 @@ type RecommendationSet struct {
 	Workload      Workload `gorm:"foreignKey:WorkloadID"`
 	ContainerName string
 
-	CPURequestCurrent    *float64
-	MemoryRequestCurrent *float64
+	CPURequestCurrent    *float64 `gorm:"column:cpu_request_current;type:numeric(10,4)"`
+	MemoryRequestCurrent *float64 `gorm:"column:memory_request_current;type:numeric(20,4)"`
 
 	// Variation fields: percent of current CPU/memory request (aligned with API response).
 	CPUVariationShortCostPct            *float64 `gorm:"column:cpu_variation_short_cost_pct;type:numeric(10,4)"`

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -163,36 +163,36 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 
 			containers := recommendation[0].Kubernetes_objects[0].Containers
 			for _, container := range containers {
-			if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
-				for _, v := range container.Recommendations.Data {
-					marshalData, err := json.Marshal(v)
-					if err != nil {
-						log.Errorf("unable to list recommendation for: %v", err)
-						continue
-					}
-					extractedRecommVals := model.ExtractRecommendationColumnValues(v)
-					// Create RecommendationSet entry into the table.
-					recommendationSet := model.RecommendationSet{
-						WorkloadID:                          kafkaMsg.Metadata.Workload_id,
-						ContainerName:                       container.Container_name,
-						CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
-						MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
-						CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
-						CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
-						CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
-						CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
-						CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
-						CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
-						MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
-						MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
-						MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
-						MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
-						MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
-						MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
-						MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
-						MonitoringEndTime:                   v.MonitoringEndTime,
-						Recommendations:                     marshalData,
-					}
+				if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
+					for _, v := range container.Recommendations.Data {
+						marshalData, err := json.Marshal(v)
+						if err != nil {
+							log.Errorf("unable to list recommendation for: %v", err)
+							continue
+						}
+						extractedRecommVals := model.ExtractRecommendationColumnValues(v)
+						// Create RecommendationSet entry into the table.
+						recommendationSet := model.RecommendationSet{
+							WorkloadID:                          kafkaMsg.Metadata.Workload_id,
+							ContainerName:                       container.Container_name,
+							CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
+							MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
+							CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
+							CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
+							CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
+							CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
+							CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
+							CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
+							MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
+							MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
+							MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
+							MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
+							MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
+							MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
+							MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
+							MonitoringEndTime:                   v.MonitoringEndTime,
+							Recommendations:                     marshalData,
+						}
 						recommendationSetList = append(recommendationSetList, recommendationSet)
 
 						// Create entry into HistoricalRecommendationSet table.

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -163,21 +163,36 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 
 			containers := recommendation[0].Kubernetes_objects[0].Containers
 			for _, container := range containers {
-				if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
-					for _, v := range container.Recommendations.Data {
-						marshalData, err := json.Marshal(v)
-						if err != nil {
-							log.Errorf("unable to list recommendation for: %v", err)
-							continue
-						}
-						// Create RecommendationSet entry into the table.
-						recommendationSet := model.RecommendationSet{
-							WorkloadID:          kafkaMsg.Metadata.Workload_id,
-							ContainerName:       container.Container_name,
-							MonitoringStartTime: v.RecommendationTerms.Short_term.MonitoringStartTime,
-							MonitoringEndTime:   v.MonitoringEndTime,
-							Recommendations:     marshalData,
-						}
+			if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
+				for _, v := range container.Recommendations.Data {
+					marshalData, err := json.Marshal(v)
+					if err != nil {
+						log.Errorf("unable to list recommendation for: %v", err)
+						continue
+					}
+					extractedRecommVals := model.ExtractRecommendationColumnValues(v)
+					// Create RecommendationSet entry into the table.
+					recommendationSet := model.RecommendationSet{
+						WorkloadID:                          kafkaMsg.Metadata.Workload_id,
+						ContainerName:                       container.Container_name,
+						CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
+						MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
+						CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
+						CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
+						CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
+						CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
+						CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
+						CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
+						MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
+						MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
+						MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
+						MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
+						MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
+						MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
+						MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
+						MonitoringEndTime:                   v.MonitoringEndTime,
+						Recommendations:                     marshalData,
+					}
 						recommendationSetList = append(recommendationSetList, recommendationSet)
 
 						// Create entry into HistoricalRecommendationSet table.

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -159,21 +159,36 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 
 			containers := recommendation[0].Kubernetes_objects[0].Containers
 			for _, container := range containers {
-				if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
-					for _, v := range container.Recommendations.Data {
-						marshalData, err := json.Marshal(v)
-						if err != nil {
-							log.Errorf("unable to list recommendation for: %v", err)
-							continue
-						}
-						// Create RecommendationSet entry into the table.
-						recommendationSet := model.RecommendationSet{
-							WorkloadID:          kafkaMsg.Metadata.Workload_id,
-							ContainerName:       container.Container_name,
-							MonitoringStartTime: v.RecommendationTerms.Short_term.MonitoringStartTime,
-							MonitoringEndTime:   v.MonitoringEndTime,
-							Recommendations:     marshalData,
-						}
+			if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
+				for _, v := range container.Recommendations.Data {
+					marshalData, err := json.Marshal(v)
+					if err != nil {
+						log.Errorf("unable to list recommendation for: %v", err)
+						continue
+					}
+					extractedRecommVals := model.ExtractRecommendationColumnValues(v)
+					// Create RecommendationSet entry into the table.
+					recommendationSet := model.RecommendationSet{
+						WorkloadID:                          kafkaMsg.Metadata.Workload_id,
+						ContainerName:                       container.Container_name,
+						CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
+						MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
+						CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
+						CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
+						CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
+						CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
+						CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
+						CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
+						MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
+						MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
+						MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
+						MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
+						MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
+						MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
+						MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
+						MonitoringEndTime:                   v.MonitoringEndTime,
+						Recommendations:                     marshalData,
+					}
 						recommendationSetList = append(recommendationSetList, recommendationSet)
 
 						// Create entry into HistoricalRecommendationSet table.

--- a/internal/services/recommendation_poller.go
+++ b/internal/services/recommendation_poller.go
@@ -159,36 +159,36 @@ func requestAndSaveRecommendation(kafkaMsg types.RecommendationKafkaMsg, recomme
 
 			containers := recommendation[0].Kubernetes_objects[0].Containers
 			for _, container := range containers {
-			if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
-				for _, v := range container.Recommendations.Data {
-					marshalData, err := json.Marshal(v)
-					if err != nil {
-						log.Errorf("unable to list recommendation for: %v", err)
-						continue
-					}
-					extractedRecommVals := model.ExtractRecommendationColumnValues(v)
-					// Create RecommendationSet entry into the table.
-					recommendationSet := model.RecommendationSet{
-						WorkloadID:                          kafkaMsg.Metadata.Workload_id,
-						ContainerName:                       container.Container_name,
-						CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
-						MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
-						CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
-						CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
-						CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
-						CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
-						CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
-						CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
-						MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
-						MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
-						MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
-						MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
-						MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
-						MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
-						MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
-						MonitoringEndTime:                   v.MonitoringEndTime,
-						Recommendations:                     marshalData,
-					}
+				if kruize.IsValidRecommendation(container.Recommendations, experiment_name, maxEndTimeFromReport, types.PayloadTypeContainer) {
+					for _, v := range container.Recommendations.Data {
+						marshalData, err := json.Marshal(v)
+						if err != nil {
+							log.Errorf("unable to list recommendation for: %v", err)
+							continue
+						}
+						extractedRecommVals := model.ExtractRecommendationColumnValues(v)
+						// Create RecommendationSet entry into the table.
+						recommendationSet := model.RecommendationSet{
+							WorkloadID:                          kafkaMsg.Metadata.Workload_id,
+							ContainerName:                       container.Container_name,
+							CPURequestCurrent:                   extractedRecommVals.CPURequestCurrent,
+							MemoryRequestCurrent:                extractedRecommVals.MemoryRequestCurrent,
+							CPUVariationShortCostPct:            extractedRecommVals.CPUVariationShortCostPct,
+							CPUVariationShortPerformancePct:     extractedRecommVals.CPUVariationShortPerformancePct,
+							CPUVariationMediumCostPct:           extractedRecommVals.CPUVariationMediumCostPct,
+							CPUVariationMediumPerformancePct:    extractedRecommVals.CPUVariationMediumPerformancePct,
+							CPUVariationLongCostPct:             extractedRecommVals.CPUVariationLongCostPct,
+							CPUVariationLongPerformancePct:      extractedRecommVals.CPUVariationLongPerformancePct,
+							MemoryVariationShortCostPct:         extractedRecommVals.MemoryVariationShortCostPct,
+							MemoryVariationShortPerformancePct:  extractedRecommVals.MemoryVariationShortPerformancePct,
+							MemoryVariationMediumCostPct:        extractedRecommVals.MemoryVariationMediumCostPct,
+							MemoryVariationMediumPerformancePct: extractedRecommVals.MemoryVariationMediumPerformancePct,
+							MemoryVariationLongCostPct:          extractedRecommVals.MemoryVariationLongCostPct,
+							MemoryVariationLongPerformancePct:   extractedRecommVals.MemoryVariationLongPerformancePct,
+							MonitoringStartTime:                 v.RecommendationTerms.Short_term.MonitoringStartTime,
+							MonitoringEndTime:                   v.MonitoringEndTime,
+							Recommendations:                     marshalData,
+						}
 						recommendationSetList = append(recommendationSetList, recommendationSet)
 
 						// Create entry into HistoricalRecommendationSet table.

--- a/internal/utils/conversion.go
+++ b/internal/utils/conversion.go
@@ -6,6 +6,21 @@ import (
 	"strings"
 )
 
+// maxNumeric10_4Magnitude is the maximum absolute value storable in PostgreSQL NUMERIC(10,4)
+// (6 digits + 4 decimal places; see "numeric field overflow" in Postgres when |v| >= 1e6).
+// Variation "percent" values that exceed this after truncation must be clamped for DB columns.
+const maxNumeric10_4Magnitude = 999_999.9999
+
+func clampToNumeric10_4Range(p float64) float64 {
+	if p > maxNumeric10_4Magnitude {
+		return maxNumeric10_4Magnitude
+	}
+	if p < -maxNumeric10_4Magnitude {
+		return -maxNumeric10_4Magnitude
+	}
+	return p
+}
+
 // CalculatePercentage returns (numerator / denominator) * 100.
 // If numerator or denominator is zero, it returns 0 to avoid Inf/NaN from division by zero.
 func CalculatePercentage(numerator, denominator float64) float64 {
@@ -50,7 +65,8 @@ func VariationPercentOfRequestCPU(variationCores, currentCores float64) float64 
 	v := TruncateToThreeDecimalPlaces(variationCores)
 	d := TruncateToThreeDecimalPlaces(currentCores)
 	p := CalculatePercentage(v, d)
-	return TruncateToThreeDecimalPlaces(p)
+	p = TruncateToThreeDecimalPlaces(p)
+	return clampToNumeric10_4Range(p)
 }
 
 // VariationPercentOfRequestMemoryBytesMiB computes request variation as percent of current memory request
@@ -59,5 +75,6 @@ func VariationPercentOfRequestMemoryBytesMiB(variationBytes, currentBytes float6
 	v := TruncateMemoryBytesToMiBTwoDecimals(variationBytes)
 	d := TruncateMemoryBytesToMiBTwoDecimals(currentBytes)
 	p := CalculatePercentage(v, d)
-	return TruncateToThreeDecimalPlaces(p)
+	p = TruncateToThreeDecimalPlaces(p)
+	return clampToNumeric10_4Range(p)
 }

--- a/internal/utils/conversion.go
+++ b/internal/utils/conversion.go
@@ -11,7 +11,7 @@ import (
 // Variation "percent" values that exceed this after truncation must be clamped for DB columns.
 const maxNumeric10_4Magnitude = 999_999.9999
 
-func clampToNumeric10_4Range(p float64) float64 {
+func ClampToNumeric10_4Range(p float64) float64 {
 	if math.IsNaN(p) || math.IsInf(p, 0) {
 		return 0
 	}
@@ -28,7 +28,7 @@ func clampToNumeric10_4Range(p float64) float64 {
 // (16 digits + 4 decimal places; Postgres overflows when |v| >= 1e16).
 const maxNumeric20_4Magnitude = 9_999_999_999_999_999.9999
 
-func clampToNumeric20_4Range(v float64) float64 {
+func ClampToNumeric20_4Range(v float64) float64 {
 	if math.IsNaN(v) || math.IsInf(v, 0) {
 		return 0
 	}
@@ -39,16 +39,6 @@ func clampToNumeric20_4Range(v float64) float64 {
 		return -maxNumeric20_4Magnitude
 	}
 	return v
-}
-
-// ClampToNumeric10_4 clamps a value into the PostgreSQL NUMERIC(10,4) range.
-func ClampToNumeric10_4(v float64) float64 {
-	return clampToNumeric10_4Range(v)
-}
-
-// ClampToNumeric20_4 clamps a value into the PostgreSQL NUMERIC(20,4) range.
-func ClampToNumeric20_4(v float64) float64 {
-	return clampToNumeric20_4Range(v)
 }
 
 // CalculatePercentage returns (numerator / denominator) * 100.
@@ -96,7 +86,7 @@ func VariationPercentOfRequestCPU(variationCores, currentCores float64) float64 
 	d := TruncateToThreeDecimalPlaces(currentCores)
 	p := CalculatePercentage(v, d)
 	p = TruncateToThreeDecimalPlaces(p)
-	return clampToNumeric10_4Range(p)
+	return ClampToNumeric10_4Range(p)
 }
 
 // VariationPercentOfRequestMemoryBytesMiB computes request variation as percent of current memory request
@@ -106,5 +96,5 @@ func VariationPercentOfRequestMemoryBytesMiB(variationBytes, currentBytes float6
 	d := TruncateMemoryBytesToMiBTwoDecimals(currentBytes)
 	p := CalculatePercentage(v, d)
 	p = TruncateToThreeDecimalPlaces(p)
-	return clampToNumeric10_4Range(p)
+	return ClampToNumeric10_4Range(p)
 }

--- a/internal/utils/conversion.go
+++ b/internal/utils/conversion.go
@@ -12,6 +12,9 @@ import (
 const maxNumeric10_4Magnitude = 999_999.9999
 
 func clampToNumeric10_4Range(p float64) float64 {
+	if math.IsNaN(p) || math.IsInf(p, 0) {
+		return 0
+	}
 	if p > maxNumeric10_4Magnitude {
 		return maxNumeric10_4Magnitude
 	}
@@ -19,6 +22,33 @@ func clampToNumeric10_4Range(p float64) float64 {
 		return -maxNumeric10_4Magnitude
 	}
 	return p
+}
+
+// maxNumeric20_4Magnitude is the maximum absolute value storable in PostgreSQL NUMERIC(20,4)
+// (16 digits + 4 decimal places; Postgres overflows when |v| >= 1e16).
+const maxNumeric20_4Magnitude = 9_999_999_999_999_999.9999
+
+func clampToNumeric20_4Range(v float64) float64 {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0
+	}
+	if v > maxNumeric20_4Magnitude {
+		return maxNumeric20_4Magnitude
+	}
+	if v < -maxNumeric20_4Magnitude {
+		return -maxNumeric20_4Magnitude
+	}
+	return v
+}
+
+// ClampToNumeric10_4 clamps a value into the PostgreSQL NUMERIC(10,4) range.
+func ClampToNumeric10_4(v float64) float64 {
+	return clampToNumeric10_4Range(v)
+}
+
+// ClampToNumeric20_4 clamps a value into the PostgreSQL NUMERIC(20,4) range.
+func ClampToNumeric20_4(v float64) float64 {
+	return clampToNumeric20_4Range(v)
 }
 
 // CalculatePercentage returns (numerator / denominator) * 100.

--- a/internal/utils/conversion_test.go
+++ b/internal/utils/conversion_test.go
@@ -23,3 +23,17 @@ func TestVariationPercentOfRequestMemoryBytesMiB_rowOrderMatchesDisplay(t *testi
 		t.Fatalf("MiB-aligned %%: expected row B > row A (%.4f vs %.4f)", pctB, pctA)
 	}
 }
+
+// Regression: extreme (variation/current) must not exceed PostgreSQL NUMERIC(10,4) (|v| < 1e6).
+func TestVariationPercentOfRequest_clampsToNumeric10_4(t *testing.T) {
+	// After 3dp cores truncation, current stays 0.001; (100/0.001)*100 = 1e7 %, unclamped
+	cpu := VariationPercentOfRequestCPU(100.0, 0.001)
+	if cpu != maxNumeric10_4Magnitude {
+		t.Fatalf("CPU: got %v, want %v", cpu, maxNumeric10_4Magnitude)
+	}
+	// 1 PiB-like variation vs 1 MiB current request → |%| > 1e6 before clamp
+	mem := VariationPercentOfRequestMemoryBytesMiB(1e12, 1048576)
+	if mem != maxNumeric10_4Magnitude {
+		t.Fatalf("memory: got %v, want %v", mem, maxNumeric10_4Magnitude)
+	}
+}

--- a/migrations/000024_recommendation_sets_add_current_request_columns.down.sql
+++ b/migrations/000024_recommendation_sets_add_current_request_columns.down.sql
@@ -1,0 +1,4 @@
+-- Roll back 000024: drop current request columns from recommendation_sets.
+ALTER TABLE recommendation_sets
+    DROP COLUMN IF EXISTS cpu_request_current,
+    DROP COLUMN IF EXISTS memory_request_current;

--- a/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
+++ b/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
@@ -2,5 +2,5 @@
 -- Existing rows remain NULL; the poller fills values for new records.
 -- List queries use ORDER BY ... DESC NULLS LAST (see listoptions.SQLOrderByFragment).
 ALTER TABLE recommendation_sets
-    ADD COLUMN cpu_request_current NUMERIC(10, 4),
-    ADD COLUMN memory_request_current NUMERIC(10, 4);
+    ADD COLUMN cpu_request_current FLOAT,
+    ADD COLUMN memory_request_current FLOAT;

--- a/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
+++ b/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
@@ -2,5 +2,5 @@
 -- Existing rows remain NULL; the poller fills values for new records.
 -- List queries use ORDER BY ... DESC NULLS LAST (see listoptions.SQLOrderByFragment).
 ALTER TABLE recommendation_sets
-    ADD COLUMN cpu_request_current FLOAT,
-    ADD COLUMN memory_request_current FLOAT;
+    ADD COLUMN cpu_request_current NUMERIC(10, 4),
+    ADD COLUMN memory_request_current NUMERIC(10, 4);

--- a/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
+++ b/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
@@ -1,0 +1,6 @@
+-- Add current request columns to recommendation_sets for sorting (mirrors namespace_recommendation_sets).
+-- Existing rows remain NULL; the poller fills values for new records.
+-- List queries use ORDER BY ... DESC NULLS LAST (see listoptions.SQLOrderByFragment).
+ALTER TABLE recommendation_sets
+    ADD COLUMN cpu_request_current FLOAT,
+    ADD COLUMN memory_request_current FLOAT;

--- a/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
+++ b/migrations/000024_recommendation_sets_add_current_request_columns.up.sql
@@ -2,5 +2,5 @@
 -- Existing rows remain NULL; the poller fills values for new records.
 -- List queries use ORDER BY ... DESC NULLS LAST (see listoptions.SQLOrderByFragment).
 ALTER TABLE recommendation_sets
-    ADD COLUMN cpu_request_current FLOAT,
-    ADD COLUMN memory_request_current FLOAT;
+    ADD COLUMN cpu_request_current NUMERIC(10, 4),
+    ADD COLUMN memory_request_current NUMERIC(20, 4);

--- a/migrations/000025_namespace_recommendation_sets_current_request_numeric.down.sql
+++ b/migrations/000025_namespace_recommendation_sets_current_request_numeric.down.sql
@@ -1,0 +1,5 @@
+-- Roll back 000025: restore namespace current request columns to FLOAT.
+ALTER TABLE namespace_recommendation_sets
+    ALTER COLUMN cpu_request_current TYPE FLOAT,
+    ALTER COLUMN memory_request_current TYPE FLOAT;
+

--- a/migrations/000025_namespace_recommendation_sets_current_request_numeric.up.sql
+++ b/migrations/000025_namespace_recommendation_sets_current_request_numeric.up.sql
@@ -1,0 +1,6 @@
+-- Alter namespace current request columns to fixed-precision numeric.
+-- cpu_request_current stores cores; memory_request_current stores bytes.
+ALTER TABLE namespace_recommendation_sets
+    ALTER COLUMN cpu_request_current TYPE NUMERIC(10, 4),
+    ALTER COLUMN memory_request_current TYPE NUMERIC(20, 4);
+

--- a/openapi.json
+++ b/openapi.json
@@ -1287,8 +1287,7 @@
                       },
                       "format": {
                         "type": "string",
-                        "example": null,
-                        "nullable": true
+                        "example": "percent"
                       }
                     }
                   },
@@ -1302,7 +1301,7 @@
                       },
                       "format": {
                         "type": "string",
-                        "example": "Mi"
+                        "example": "percent"
                       }
                     }
                   }
@@ -1452,8 +1451,7 @@
                       },
                       "format": {
                         "type": "string",
-                        "example": null,
-                        "nullable": true
+                        "example": "percent"
                       }
                     }
                   },
@@ -1467,7 +1465,7 @@
                       },
                       "format": {
                         "type": "string",
-                        "example": "Mi"
+                        "example": "percent"
                       }
                     }
                   }

--- a/openapi.json
+++ b/openapi.json
@@ -222,10 +222,32 @@
           {
             "name": "order_by",
             "in": "query",
-            "description": "Options are cluster, project, workload_type, workload, container, last_reported",
+            "description": "Field to order results by. Options: cluster, project, workload_type, workload, container, last_reported, cpu_request_current, memory_request_current, and per-term variation fields (e.g. cpu_variation_short_cost, memory_variation_long_performance). Variation values are percent of current CPU or memory request (float); see the recommendations.variation amounts in each list item.",
             "required": false,
             "schema": {
               "type": "string",
+              "enum": [
+                "cluster",
+                "project",
+                "workload_type",
+                "workload",
+                "container",
+                "last_reported",
+                "cpu_request_current",
+                "memory_request_current",
+                "cpu_variation_short_cost",
+                "cpu_variation_short_performance",
+                "cpu_variation_medium_cost",
+                "cpu_variation_medium_performance",
+                "cpu_variation_long_cost",
+                "cpu_variation_long_performance",
+                "memory_variation_short_cost",
+                "memory_variation_short_performance",
+                "memory_variation_medium_cost",
+                "memory_variation_medium_performance",
+                "memory_variation_long_cost",
+                "memory_variation_long_performance"
+              ],
               "example": "last_reported"
             }
           },


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title
3. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Store pre-computed variation percentages for container and namespace recommendations and use them to drive API responses and sorting.

New Features:
- Expose new ordering options on container recommendations for current CPU/memory requests and per-term CPU/memory variation percentages.

Enhancements:
- Embed stored variation percentage fields in recommendation result models and wire them into list and detail handlers for API response shaping.
- Extend recommendation poller to persist current request values and per-term CPU/memory variation percentages into recommendation_sets.
- Adjust variation-to-percentage transformation to optionally reuse stored request variation percentages rather than recomputing from JSON.
- Update SQL list options and tests so container recommendation queries sort on the new *_pct and current request columns.

Tests:
- Expand list options tests to cover ordering by container current requests and variation percentage columns.

Chores:
- Add a database migration to introduce current CPU/memory request columns on recommendation_sets with rollback support.