### PR TITLE
RHINENG-26044 cluster alias value need not be sanitized

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -239,10 +239,7 @@ func parseClusterParams(value string, mode string) ([]string, []string, error) {
 		}
 		return []string{"clusters.cluster_uuid" + suffix}, []string{value}, nil
 	}
-	s, err := sanitizeParamValue("cluster", value, model.ClusterMaxLen, true)
-	if err != nil {
-		return nil, nil, err
-	}
+	s := value
 	if modeClause.Wrap {
 		s = "%" + s + "%"
 	}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

cluster alias value need not be sanitized since upstream has no such validations 


## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:
NA

## Summary by Sourcery

Bug Fixes:
- Allow raw cluster alias values in cluster parameter parsing instead of enforcing local sanitization rules.