### PR TITLE
Fixes #RHINENG-25931 - Reduce duplication of term/engine literals

### DIFF
--- a/internal/api/kruize_constants.go
+++ b/internal/api/kruize_constants.go
@@ -1,0 +1,18 @@
+package api
+
+const (
+	// Canonical Kruize recommendation term keys as they appear in the JSON payload.
+	KruizeShortTerm  = "short_term"
+	KruizeMediumTerm = "medium_term"
+	KruizeLongTerm   = "long_term"
+
+	// Canonical Kruize recommendation engine keys as they appear in the JSON payload.
+	KruizeEngineCost        = "cost"
+	KruizeEnginePerformance = "performance"
+)
+
+// Keep ordering stable for deterministic iteration.
+var kruizeRecommendationTerms = []string{KruizeShortTerm, KruizeMediumTerm, KruizeLongTerm}
+
+// Keep ordering stable for deterministic iteration.
+var kruizeRecommendationEngines = []string{KruizeEngineCost, KruizeEnginePerformance}

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -571,7 +571,7 @@ func transformComponentUnits(unitsToTransform map[string]string, updateUnitsk8s 
 		return recommendationJSON
 	}
 
-	for _, period := range []string{"short_term", "medium_term", "long_term"} {
+	for _, period := range kruizeRecommendationTerms {
 		intervalData, ok := recommendation_terms[period].(map[string]interface{})
 		if !ok {
 			continue
@@ -630,7 +630,7 @@ func transformComponentUnits(unitsToTransform map[string]string, updateUnitsk8s 
 		}
 
 		if intervalData["recommendation_engines"] != nil {
-			for _, recommendationType := range []string{"cost", "performance"} {
+			for _, recommendationType := range kruizeRecommendationEngines {
 				engineData, ok := intervalData["recommendation_engines"].(map[string]interface{})[recommendationType].(map[string]interface{})
 				if !ok {
 					continue
@@ -709,18 +709,20 @@ func filterNotifications(recommendationID string, clusterUUID string, recommenda
 		return recommendationJSON
 	}
 
-	for _, term := range []string{"short_term", "medium_term", "long_term"} {
+	for _, term := range kruizeRecommendationTerms {
 		levelThree, ok := recommendationTerms[term].(map[string]interface{})
-		if ok {
-			deleteNotificationObject(levelThree)
+		if !ok {
+			continue
 		}
-		recommendationEngineObject, ok := levelThree["recommendation_engines"].(map[string]interface{})
-		if ok {
-			for _, engine := range []string{"cost", "performance"} {
-				levelFour, ok := recommendationEngineObject[engine].(map[string]interface{})
-				if ok {
-					deleteNotificationObject(levelFour)
-				}
+		deleteNotificationObject(levelThree)
+		recommendationEngineObject, okEngines := levelThree["recommendation_engines"].(map[string]interface{})
+		if !okEngines {
+			continue
+		}
+		for _, engine := range kruizeRecommendationEngines {
+			levelFour, ok := recommendationEngineObject[engine].(map[string]interface{})
+			if ok {
+				deleteNotificationObject(levelFour)
 			}
 		}
 	}
@@ -737,7 +739,7 @@ func dropBoxPlotsObject(recommendationJSON map[string]interface{}) map[string]in
 		return recommendationJSON
 	}
 
-	for _, period := range []string{"short_term", "medium_term", "long_term"} {
+	for _, period := range kruizeRecommendationTerms {
 		intervalData, ok := recommendation_terms[period].(map[string]interface{})
 		if !ok {
 			continue
@@ -794,14 +796,14 @@ func convertVariationToPercentage(recommendationJSON map[string]interface{}, ski
 		return recommendationJSON
 	}
 
-	for _, period := range []string{"short_term", "medium_term", "long_term"} {
+	for _, period := range kruizeRecommendationTerms {
 		intervalData, ok := recommendation_terms[period].(map[string]interface{})
 		if !ok {
 			continue
 		}
 
 		if intervalData["recommendation_engines"] != nil {
-			for _, recommendationType := range []string{"cost", "performance"} {
+			for _, recommendationType := range kruizeRecommendationEngines {
 				engineData, ok := intervalData["recommendation_engines"].(map[string]interface{})[recommendationType].(map[string]interface{})
 				if !ok {
 					continue
@@ -868,8 +870,8 @@ func injectStoredRequestVariationPct(data map[string]interface{}, pcts *model.St
 	if !ok {
 		return data
 	}
-	for _, period := range []string{"short_term", "medium_term", "long_term"} {
-		intervalData, ok := terms[period].(map[string]interface{})
+	for _, spec := range model.StoredVariationSpecs {
+		intervalData, ok := terms[spec.Term].(map[string]interface{})
 		if !ok {
 			continue
 		}
@@ -877,28 +879,26 @@ func injectStoredRequestVariationPct(data map[string]interface{}, pcts *model.St
 		if !ok {
 			continue
 		}
-		for _, engineName := range []string{"cost", "performance"} {
-			engine, ok := engines[engineName].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			variation, ok := engine["variation"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			requests, ok := variation["requests"].(map[string]interface{})
-			if !ok {
-				continue
-			}
-			cpuPct, memPct := pcts.Lookup(period, engineName)
-			if cpu, ok := requests["cpu"].(map[string]interface{}); ok && cpuPct != nil {
-				cpu["amount"] = *cpuPct
-				cpu["format"] = "percent"
-			}
-			if mem, ok := requests["memory"].(map[string]interface{}); ok && memPct != nil {
-				mem["amount"] = *memPct
-				mem["format"] = "percent"
-			}
+		engine, ok := engines[spec.Engine].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		variation, ok := engine["variation"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		requests, ok := variation["requests"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		cpuPct, memPct := spec.CPU(pcts), spec.Mem(pcts)
+		if cpu, ok := requests["cpu"].(map[string]interface{}); ok && cpuPct != nil {
+			cpu["amount"] = *cpuPct
+			cpu["format"] = "percent"
+		}
+		if mem, ok := requests["memory"].(map[string]interface{}); ok && memPct != nil {
+			mem["amount"] = *memPct
+			mem["format"] = "percent"
 		}
 	}
 	return data
@@ -957,9 +957,9 @@ func GenerateCSVRows(recommendationSet model.RecommendationSetResult) ([][]strin
 		term kruizePayload.RecommendationTerm
 	}
 	orderedTerms := []namedTerm{
-		{"short_term", recommendationObj.RecommendationTerms.Short_term},
-		{"medium_term", recommendationObj.RecommendationTerms.Medium_term},
-		{"long_term", recommendationObj.RecommendationTerms.Long_term},
+		{KruizeShortTerm, recommendationObj.RecommendationTerms.Short_term},
+		{KruizeMediumTerm, recommendationObj.RecommendationTerms.Medium_term},
+		{KruizeLongTerm, recommendationObj.RecommendationTerms.Long_term},
 	}
 
 	type namedEngine struct {
@@ -974,8 +974,8 @@ func GenerateCSVRows(recommendationSet model.RecommendationSetResult) ([][]strin
 			continue
 		}
 		orderedEngines := []namedEngine{
-			{"cost", recommendationTerm.RecommendationEngines.Cost},
-			{"performance", recommendationTerm.RecommendationEngines.Performance},
+			{KruizeEngineCost, recommendationTerm.RecommendationEngines.Cost},
+			{KruizeEnginePerformance, recommendationTerm.RecommendationEngines.Performance},
 		}
 		for _, ne := range orderedEngines {
 			recommendationType := ne.name

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -112,10 +112,10 @@ func TestGenerateCSVRows_TermOrdering(t *testing.T) {
 
 	// Column index 18 = termName, column index 21 = recommendationType
 	expectedOrder := [][2]string{
-		{"short_term", "cost"},
-		{"short_term", "performance"},
-		{"medium_term", "cost"},
-		{"medium_term", "performance"},
+		{KruizeShortTerm, KruizeEngineCost},
+		{KruizeShortTerm, KruizeEnginePerformance},
+		{KruizeMediumTerm, KruizeEngineCost},
+		{KruizeMediumTerm, KruizeEnginePerformance},
 	}
 
 	for i, exp := range expectedOrder {

--- a/internal/model/common.go
+++ b/internal/model/common.go
@@ -37,6 +37,56 @@ type StoredVariationPcts struct {
 	MemoryVariationLongPerformancePct   *float64 `gorm:"column:memory_variation_long_performance_pct" json:"-"`
 }
 
+// StoredVariationSpec is the single source of truth for supported term/engine combinations
+// and how they map to stored DB percentage columns in StoredVariationPcts.
+type StoredVariationSpec struct {
+	Term   string
+	Engine string
+	CPU    func(*StoredVariationPcts) *float64
+	Mem    func(*StoredVariationPcts) *float64
+}
+
+// StoredVariationSpecs enumerates all supported term/engine pairs.
+// Keep this list in sync with DB columns and API JSON injection.
+var StoredVariationSpecs = []StoredVariationSpec{
+	{
+		Term:   "short_term",
+		Engine: "cost",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationShortCostPct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationShortCostPct },
+	},
+	{
+		Term:   "short_term",
+		Engine: "performance",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationShortPerformancePct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationShortPerformancePct },
+	},
+	{
+		Term:   "medium_term",
+		Engine: "cost",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationMediumCostPct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationMediumCostPct },
+	},
+	{
+		Term:   "medium_term",
+		Engine: "performance",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationMediumPerformancePct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationMediumPerformancePct },
+	},
+	{
+		Term:   "long_term",
+		Engine: "cost",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationLongCostPct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationLongCostPct },
+	},
+	{
+		Term:   "long_term",
+		Engine: "performance",
+		CPU:    func(s *StoredVariationPcts) *float64 { return s.CPUVariationLongPerformancePct },
+		Mem:    func(s *StoredVariationPcts) *float64 { return s.MemoryVariationLongPerformancePct },
+	},
+}
+
 // HasValues reports whether at least one stored percentage is non-nil.
 func (s *StoredVariationPcts) HasValues() bool {
 	return s.CPUVariationShortCostPct != nil ||
@@ -56,19 +106,10 @@ func (s *StoredVariationPcts) HasValues() bool {
 // Lookup returns the stored CPU and memory variation pct for a given term (e.g. "short_term") and
 // engine name (e.g. "cost"). Returns (nil, nil) when the combination is not recognised.
 func (s *StoredVariationPcts) Lookup(term, engine string) (cpu, mem *float64) {
-	switch {
-	case term == "short_term" && engine == "cost":
-		return s.CPUVariationShortCostPct, s.MemoryVariationShortCostPct
-	case term == "short_term" && engine == "performance":
-		return s.CPUVariationShortPerformancePct, s.MemoryVariationShortPerformancePct
-	case term == "medium_term" && engine == "cost":
-		return s.CPUVariationMediumCostPct, s.MemoryVariationMediumCostPct
-	case term == "medium_term" && engine == "performance":
-		return s.CPUVariationMediumPerformancePct, s.MemoryVariationMediumPerformancePct
-	case term == "long_term" && engine == "cost":
-		return s.CPUVariationLongCostPct, s.MemoryVariationLongCostPct
-	case term == "long_term" && engine == "performance":
-		return s.CPUVariationLongPerformancePct, s.MemoryVariationLongPerformancePct
+	for _, spec := range StoredVariationSpecs {
+		if spec.Term == term && spec.Engine == engine {
+			return spec.CPU(s), spec.Mem(s)
+		}
 	}
 	return nil, nil
 }


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHIROS-XXX - Title
2. RHIROS-XXX Title
3. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Deduplicate Kruize term and engine literals by centralizing them into shared constants and specification structures, and update API and model logic to use these canonical definitions.

Enhancements:
- Introduce shared constants for Kruize recommendation term and engine keys to replace repeated string literals across the API.
- Add a single source of truth specification for supported term/engine combinations that drives both DB lookup and JSON injection of stored variation percentages.
- Refactor iteration over recommendation terms and engines in API utilities and CSV generation to rely on the new constants and specs for consistent, deterministic behavior.