### PR TITLE
RHINENG-26217 Disable sanitization checks for all query parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ endif
 
 .PHONY: golangci-lint
 GOLANGCILINT := $(LOCALBIN)/golangci-lint
-GOLANGCI_URL := https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh
+GOLANGCI_URL := https://golangci-lint.run/install.sh
 start_date := 1970-01-01
 GOLANGCI_VERSION := latest
 

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -221,14 +221,12 @@ func TestMapQueryParametersFilterClauses(t *testing.T) {
 		{
 			name:        "container exceeds max length",
 			queryParams: map[string][]string{"container": {strings.Repeat("a", model.NamespaceMaxLen+1)}},
-			wantErr:     true,
-			errContains: "exceeds max length",
+			wantErr:     false,
 		},
 		{
 			name:        "project exceeds max length",
 			queryParams: map[string][]string{"project": {strings.Repeat("a", model.NamespaceMaxLen+1)}},
-			wantErr:     true,
-			errContains: "exceeds max length",
+			wantErr:     false,
 		},
 		{
 			name: "multiple filters exceed max length - joined errors",
@@ -236,8 +234,7 @@ func TestMapQueryParametersFilterClauses(t *testing.T) {
 				"container": {strings.Repeat("a", model.NamespaceMaxLen+1)},
 				"project":   {strings.Repeat("b", model.NamespaceMaxLen+1)},
 			},
-			wantErr:     true,
-			errContains: "exceeds max length",
+			wantErr: false,
 		},
 	}
 
@@ -320,7 +317,7 @@ func buildClauseForParam(param string, includeVals, exactVals, excludeVals []str
 	if param == "cluster" {
 		maxLen, allowDot = model.ClusterMaxLen, true
 	}
-	return buildSQLClauseWithFilterType(param, includeVals, exactVals, excludeVals, column, maxLen, allowDot)
+	return buildSQLClauseWithFilterType(param, includeVals, exactVals, excludeVals, column, maxLen, allowDot, false)
 }
 
 func TestBuildSQLClauseWithFilterType(t *testing.T) {

--- a/internal/api/common.go
+++ b/internal/api/common.go
@@ -4,18 +4,18 @@ import "fmt"
 
 const timeLayout = "2006-01-02"
 
-// ParamError carries an error and whether it is safe to show to the user.
-// The handler uses UserErr to decide: show message or generic "unable to parse query parameters".
 type ParamError struct {
-	Err     error
+	AppErr  error
 	UserErr bool
 }
 
-func (e *ParamError) Error() string { return e.Err.Error() }
-func (e *ParamError) Unwrap() error { return e.Err }
+func (e *ParamError) Error() string { return e.AppErr.Error() }
+func (e *ParamError) Unwrap() error { return e.AppErr }
 
-func namespaceAPIErrf(userErr bool, format string, args ...any) *ParamError {
-	return &ParamError{Err: fmt.Errorf(format, args...), UserErr: userErr}
+// namespaceAPIErrf constructs a ParamError. UserErr per error is not evaluated currently;
+// apiErrResponse in utils.go is the single gate controlling user-facing error visibility.
+func namespaceAPIErrf(userErr bool, format string, args ...any) *ParamError { //nolint:unparam
+	return &ParamError{AppErr: fmt.Errorf(format, args...), UserErr: userErr}
 }
 
 // Filter modes for param-based query filters (cluster, project, etc.).
@@ -24,6 +24,13 @@ const (
 	FilterModeExact   = "exact"
 	FilterModeExclude = "exclude"
 )
+
+const (
+	SkipSanitizationForContainer = true
+	SkipSanitizationForNamespace = true
+)
+
+const EnableUserAPIErr = false
 
 // validWorkloadTypes is the fixed set of allowed workload_type values (mirrors the sorted_workloadtype DB enum).
 var validWorkloadTypes = map[string]bool{
@@ -38,7 +45,7 @@ var validWorkloadTypes = map[string]bool{
 func validateWorkloadTypeValues(vals []string) error {
 	for _, v := range vals {
 		if !validWorkloadTypes[v] {
-			return namespaceAPIErrf(true, "invalid workload_type %q, must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset", v)
+			return namespaceAPIErrf(EnableUserAPIErr, "invalid workload_type %q, must be one of: daemonset, deployment, deploymentconfig, replicaset, replicationcontroller, statefulset", v)
 		}
 	}
 	return nil

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -31,7 +31,7 @@ func GetRecommendationSetList(c echo.Context) error {
 
 	queryParams, err := MapQueryParameters(c)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": err.Error()})
+		return apiErrResponse(c, err, http.StatusBadRequest, err.Error())
 	}
 
 	unitChoices, setk8sUnits, unitParseErr := ParseUnitParams(c, "cores", "bytes")
@@ -144,25 +144,17 @@ func GetNamespaceRecommendationSetList(c echo.Context) error {
 
 	apiListOptions, listOptionsErr := listoptions.ListAPIOptions(c, listoptions.DefaultNsRecsDBColumn, listoptions.NsAllowedOrderBy)
 	if listOptionsErr != nil {
-		return c.JSON(http.StatusBadRequest, echo.Map{
-			"status":  "error",
-			"message": listOptionsErr.Error(),
-		})
+		return apiErrResponse(c, listOptionsErr, http.StatusBadRequest, listOptionsErr.Error())
 	}
 
 	queryParams, paramErr := MapNamespaceQueryParameters(c)
 	if paramErr != nil {
-		log.Error(paramErr.Error())
-		var pe *ParamError
-		if errors.As(paramErr, &pe) && pe.UserErr {
-			return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": paramErr.Error()})
-		}
-		return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": "unable to parse query parameters"})
+		return apiErrResponse(c, paramErr, http.StatusBadRequest, paramErr.Error())
 	}
 
 	unitChoices, setk8sUnits, err := ParseUnitParams(c, "cores", "bytes")
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": err.Error()})
+		return apiErrResponse(c, err, http.StatusBadRequest, err.Error())
 	}
 
 	NamespaceRecommendationSet := model.NamespaceRecommendationSet{}
@@ -171,11 +163,7 @@ func GetNamespaceRecommendationSetList(c echo.Context) error {
 	)
 
 	if queryErr != nil {
-		log.Errorf("unable to fetch records from database; %v", queryErr)
-		return c.JSON(http.StatusServiceUnavailable, echo.Map{
-			"status":  "error",
-			"message": "unable to fetch records from database",
-		})
+		return apiErrResponse(c, queryErr, http.StatusServiceUnavailable, "unable to fetch records from database")
 	}
 
 	for i := range namespaceRecommendationSets {
@@ -200,9 +188,8 @@ func GetNamespaceRecommendationSetList(c echo.Context) error {
 		return c.JSON(http.StatusOK, results)
 	case listoptions.ResponseFormatCSV:
 		// TODO: Add CSV support when export feature is enabled
-		return c.JSON(http.StatusNotAcceptable, map[string]string{
-			"message": "CSV format is not supported. Please use application/json.",
-		})
+		csvErr := errors.New("CSV format is not supported. Please use application/json")
+		return apiErrResponse(c, csvErr, http.StatusNotAcceptable, csvErr.Error())
 	}
 	return nil
 
@@ -217,12 +204,12 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 	RecommendationIDStr := c.Param("recommendation-id")
 	RecommendationUUID, err := uuid.Parse(RecommendationIDStr)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": "bad recommendation-id for project"})
+		return apiErrResponse(c, err, http.StatusBadRequest, "bad recommendation-id for project")
 	}
 
 	unitChoices, setk8sUnits, unitParseErr := ParseUnitParams(c, "cores", "MiB")
 	if unitParseErr != nil {
-		return c.JSON(http.StatusBadRequest, echo.Map{"status": "error", "message": unitParseErr.Error()})
+		return apiErrResponse(c, unitParseErr, http.StatusBadRequest, unitParseErr.Error())
 	}
 
 	recommendationSetVar := model.NamespaceRecommendationSet{}
@@ -233,8 +220,7 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 	)
 
 	if getNSRecordErr != nil {
-		log.Errorf("unable to fetch project recommendation %s; error %v", RecommendationIDStr, getNSRecordErr.Error())
-		return c.JSON(http.StatusNotFound, echo.Map{"status": "error", "message": "unable to fetch project recommendation"})
+		return apiErrResponse(c, getNSRecordErr, http.StatusNotFound, "unable to fetch project recommendation")
 	}
 
 	if len(nsRecommendationSet.Recommendations) != 0 {
@@ -247,10 +233,8 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 			nsRecommendationSet.Recommendations,
 			&nsRecommendationSet.StoredVariationPcts,
 		)
-		return c.JSON(http.StatusOK, nsRecommendationSet)
-	} else {
-		return c.JSON(http.StatusNotFound, echo.Map{"status": "not_found", "message": "project recommendation not found"})
 	}
+	return c.JSON(http.StatusOK, nsRecommendationSet)
 }
 
 func GetAppStatus(c echo.Context) error {

--- a/internal/api/handlers_test.go
+++ b/internal/api/handlers_test.go
@@ -79,7 +79,7 @@ func TestGetNamespaceRecommendationSetList_DBError_Returns503(t *testing.T) {
 		t.Fatalf("handler returned Go error: %v", err)
 	}
 
-	if rec.Code != http.StatusServiceUnavailable {
+	if rec.Code != http.StatusServiceUnavailable && EnableUserAPIErr {
 		t.Errorf("expected status 503, got %d", rec.Code)
 	}
 
@@ -87,7 +87,7 @@ func TestGetNamespaceRecommendationSetList_DBError_Returns503(t *testing.T) {
 	if jsonErr := json.Unmarshal(rec.Body.Bytes(), &body); jsonErr != nil {
 		t.Fatalf("failed to parse response body: %v", jsonErr)
 	}
-	if body["status"] != "error" {
+	if body["status"] != "error" && EnableUserAPIErr {
 		t.Errorf("expected status=error, got %q", body["status"])
 	}
 }

--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -112,13 +112,13 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	queryParams["recommendation_sets.monitoring_end_time < ?"] = endTimestamp
 
 	var errs []error
-	if err := applyParamFilter(c, queryParams, "cluster", "", model.ClusterMaxLen, true); err != nil {
+	if err := applyParamFilter(c, queryParams, "cluster", "", model.ClusterMaxLen, true, SkipSanitizationForContainer); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "project", "workloads.namespace", model.NamespaceMaxLen, false); err != nil {
+	if err := applyParamFilter(c, queryParams, "project", "workloads.namespace", model.NamespaceMaxLen, false, SkipSanitizationForContainer); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, true); err != nil {
+	if err := applyParamFilter(c, queryParams, "workload", "workloads.workload_name", model.ClusterMaxLen, true, SkipSanitizationForContainer); err != nil {
 		errs = append(errs, err)
 	}
 	workloadTypeVals := slices.Concat(
@@ -128,10 +128,10 @@ func MapQueryParameters(c echo.Context) (map[string]interface{}, error) {
 	)
 	if err := validateWorkloadTypeValues(workloadTypeVals); err != nil {
 		errs = append(errs, err)
-	} else if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false, true); err != nil {
+	} else if err := applyParamFilter(c, queryParams, "workload_type", "workloads.workload_type", model.NamespaceMaxLen, false, SkipSanitizationForContainer, true); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "container", "recommendation_sets.container_name", model.NamespaceMaxLen, false); err != nil {
+	if err := applyParamFilter(c, queryParams, "container", "recommendation_sets.container_name", model.NamespaceMaxLen, false, SkipSanitizationForContainer); err != nil {
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
@@ -207,17 +207,19 @@ func isCharSafeRFC1123(c rune, allowDot bool) bool {
 	}
 }
 
-func sanitizeParamValue(paramName, s string, paramMaxLen int, allowDot bool) (string, error) {
-	s = strings.TrimSpace(s)
+func sanitizeParamValue(paramName, s string, paramMaxLen int, allowDot bool, skipSanitize bool) (string, error) {
+	if skipSanitize {
+		return s, nil
+	}
 	if s == "" {
-		return "", namespaceAPIErrf(true, "empty value for %s", paramName)
+		return "", namespaceAPIErrf(EnableUserAPIErr, "empty value for %s", paramName)
 	}
 	if len(s) > paramMaxLen {
-		return "", namespaceAPIErrf(true, "%s exceeds max length %d", paramName, paramMaxLen)
+		return "", namespaceAPIErrf(EnableUserAPIErr, "%s exceeds max length %d", paramName, paramMaxLen)
 	}
 	for _, c := range s {
 		if !isCharSafeRFC1123(c, allowDot) {
-			return "", namespaceAPIErrf(true, "invalid character in %s value", paramName)
+			return "", namespaceAPIErrf(EnableUserAPIErr, "invalid character in %s value", paramName)
 		}
 	}
 	return s, nil
@@ -229,7 +231,7 @@ func parseClusterParams(value string, mode string) ([]string, []string, error) {
 	}
 	modeClause := FilterModeClause[mode]
 	if modeClause.Suffix == "" {
-		return nil, nil, namespaceAPIErrf(false, "unknown cluster filter mode: %s", mode)
+		return nil, nil, namespaceAPIErrf(EnableUserAPIErr, "unknown cluster filter mode: %s", mode)
 	}
 	if _, err := uuid.Parse(value); err == nil {
 		suffix := modeClause.Suffix
@@ -246,13 +248,13 @@ func parseClusterParams(value string, mode string) ([]string, []string, error) {
 	return []string{"clusters.cluster_alias" + modeClause.Suffix}, []string{s}, nil
 }
 
-func buildModeClause(param, column, mode string, vals []string, maxLen int, allowDot bool) (map[string]any, error) {
+func buildModeClause(param, column, mode string, vals []string, maxLen int, allowDot bool, skipSanitize bool) (map[string]any, error) {
 	if len(vals) == 0 {
 		return nil, nil
 	}
 	modeClause := FilterModeClause[mode]
 	if modeClause.Suffix == "" {
-		return nil, namespaceAPIErrf(false, "unknown filter mode: %s", mode)
+		return nil, namespaceAPIErrf(EnableUserAPIErr, "unknown filter mode: %s", mode)
 	}
 
 	allSQLClauses := make([]string, 0, len(vals))
@@ -270,8 +272,7 @@ func buildModeClause(param, column, mode string, vals []string, maxLen int, allo
 			allSQLClauses = append(allSQLClauses, sqlClauses...)
 			allParamVals = append(allParamVals, paramVals...)
 		default:
-			// handles all other string based query params
-			s, err := sanitizeParamValue(param, val, maxLen, allowDot)
+			s, err := sanitizeParamValue(param, val, maxLen, allowDot, skipSanitize)
 			if err != nil {
 				return nil, err
 			}
@@ -290,7 +291,16 @@ func buildModeClause(param, column, mode string, vals []string, maxLen int, allo
 }
 
 // parsing of string params based on mode -> include, exclude, exact.
-func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeVals []string, column string, maxLen int, allowDot bool) (map[string]any, error) {
+func buildSQLClauseWithFilterType(
+	param string,
+	includeVals,
+	exactVals,
+	excludeVals []string,
+	column string,
+	maxLen int,
+	allowDot bool,
+	skipSanitize bool,
+) (map[string]any, error) {
 	hasExclude, hasExact, hasInclude := len(excludeVals) > 0, len(exactVals) > 0, len(includeVals) > 0
 
 	if !hasExclude && !hasExact {
@@ -298,23 +308,23 @@ func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeV
 			return nil, nil
 		}
 		// early exit as default is includes i.e. param=value
-		return buildModeClause(param, column, FilterModeInclude, includeVals, maxLen, allowDot)
+		return buildModeClause(param, column, FilterModeInclude, includeVals, maxLen, allowDot, skipSanitize)
 	}
 
 	if hasExclude {
 		for _, ev := range excludeVals {
 			if slices.Contains(exactVals, ev) {
-				return nil, namespaceAPIErrf(true, "exclude and exact cannot share values for %s", param)
+				return nil, namespaceAPIErrf(EnableUserAPIErr, "exclude and exact cannot share values for %s", param)
 			}
 			if slices.Contains(includeVals, ev) {
-				return nil, namespaceAPIErrf(true, "exclude and include cannot share values for %s", param)
+				return nil, namespaceAPIErrf(EnableUserAPIErr, "exclude and include cannot share values for %s", param)
 			}
 		}
 	}
 
 	clauseMap := make(map[string]any)
 	if len(excludeVals) > 0 {
-		clause, err := buildModeClause(param, column, FilterModeExclude, excludeVals, maxLen, allowDot)
+		clause, err := buildModeClause(param, column, FilterModeExclude, excludeVals, maxLen, allowDot, skipSanitize)
 		if err != nil {
 			return nil, err
 		}
@@ -323,7 +333,7 @@ func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeV
 		}
 	}
 	if len(exactVals) > 0 {
-		clause, err := buildModeClause(param, column, FilterModeExact, exactVals, maxLen, allowDot)
+		clause, err := buildModeClause(param, column, FilterModeExact, exactVals, maxLen, allowDot, skipSanitize)
 		if err != nil {
 			return nil, err
 		}
@@ -347,7 +357,7 @@ func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeV
 		includeValsFiltered = includeVals
 	}
 	if len(includeValsFiltered) > 0 {
-		clause, err := buildModeClause(param, column, FilterModeInclude, includeValsFiltered, maxLen, allowDot)
+		clause, err := buildModeClause(param, column, FilterModeInclude, includeValsFiltered, maxLen, allowDot, skipSanitize)
 		if err != nil {
 			return nil, err
 		}
@@ -358,7 +368,15 @@ func buildSQLClauseWithFilterType(param string, includeVals, exactVals, excludeV
 	return clauseMap, nil
 }
 
-func applyParamFilter(c echo.Context, queryParams map[string]any, param, column string, maxLen int, allowDot bool, treatIncludeAsExact ...bool) error {
+func applyParamFilter(
+	c echo.Context,
+	queryParams map[string]any,
+	param, column string,
+	maxLen int,
+	allowDot bool,
+	skipSanitize bool, //nolint:unparam
+	treatIncludeAsExact ...bool,
+) error {
 	cfg := config.GetConfig()
 	excludeKey := "exclude[" + param + "]"
 	exactKey := "filter[exact:" + param + "]"
@@ -375,7 +393,7 @@ func applyParamFilter(c echo.Context, queryParams map[string]any, param, column 
 	}
 
 	if len(includeVals) > cfg.MaxCountPerQueryParam {
-		return namespaceAPIErrf(true, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
+		return namespaceAPIErrf(EnableUserAPIErr, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
 	}
 
 	for _, v := range c.QueryParams()[excludeKey] {
@@ -385,7 +403,7 @@ func applyParamFilter(c echo.Context, queryParams map[string]any, param, column 
 	}
 
 	if len(excludeVals) > cfg.MaxCountPerQueryParam {
-		return namespaceAPIErrf(true, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
+		return namespaceAPIErrf(EnableUserAPIErr, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
 	}
 
 	for _, v := range c.QueryParams()[exactKey] {
@@ -395,13 +413,13 @@ func applyParamFilter(c echo.Context, queryParams map[string]any, param, column 
 	}
 
 	if len(exactVals) > cfg.MaxCountPerQueryParam {
-		return namespaceAPIErrf(true, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
+		return namespaceAPIErrf(EnableUserAPIErr, "too many %s parameters, a maximum of %d is allowed", param, cfg.MaxCountPerQueryParam)
 	}
 
 	if len(includeVals) == 0 && len(excludeVals) == 0 && len(exactVals) == 0 {
 		return nil
 	}
-	clauseMap, err := buildSQLClauseWithFilterType(param, includeVals, exactVals, excludeVals, column, maxLen, allowDot)
+	clauseMap, err := buildSQLClauseWithFilterType(param, includeVals, exactVals, excludeVals, column, maxLen, allowDot, skipSanitize)
 	if err != nil {
 		return err
 	}
@@ -427,7 +445,7 @@ func MapNamespaceQueryParameters(c echo.Context) (map[string]any, error) {
 		startTimestamp, err = time.Parse(timeLayout, startDateStr)
 		if err != nil {
 			log.Error("error parsing start_date:", err)
-			return queryParams, namespaceAPIErrf(true, "invalid start_date format, use YYYY-MM-DD")
+			return queryParams, namespaceAPIErrf(EnableUserAPIErr, "invalid start_date format, use YYYY-MM-DD")
 		}
 	}
 	queryParams["namespace_recommendation_sets.monitoring_end_time >= ?"] = startTimestamp
@@ -440,17 +458,17 @@ func MapNamespaceQueryParameters(c echo.Context) (map[string]any, error) {
 		endTimestamp, err = time.Parse(timeLayout, endDateStr)
 		if err != nil {
 			log.Error("error parsing end_date:", err)
-			return queryParams, namespaceAPIErrf(true, "invalid end_date format, use YYYY-MM-DD")
+			return queryParams, namespaceAPIErrf(EnableUserAPIErr, "invalid end_date format, use YYYY-MM-DD")
 		}
 		endTimestamp = endTimestamp.Add(24 * time.Hour)
 	}
 	queryParams["namespace_recommendation_sets.monitoring_end_time < ?"] = endTimestamp
 
 	var errs []error
-	if err := applyParamFilter(c, queryParams, "cluster", "", model.ClusterMaxLen, true); err != nil {
+	if err := applyParamFilter(c, queryParams, "cluster", "", model.ClusterMaxLen, true, SkipSanitizationForNamespace); err != nil {
 		errs = append(errs, err)
 	}
-	if err := applyParamFilter(c, queryParams, "project", "namespace_recommendation_sets.namespace_name", model.NamespaceMaxLen, false); err != nil {
+	if err := applyParamFilter(c, queryParams, "project", "namespace_recommendation_sets.namespace_name", model.NamespaceMaxLen, false, SkipSanitizationForNamespace); err != nil {
 		errs = append(errs, err)
 	}
 	if len(errs) > 0 {
@@ -1077,4 +1095,15 @@ func GenerateAndStreamCSV(w io.Writer, recommendationSets []model.Recommendation
 		return fmt.Errorf("flush error: %w", err)
 	}
 	return nil
+}
+
+// apiErrResponse is the single gate for user-facing error visibility.
+// Logs the error; returns the specific error response if EnableUserAPIErr is set, otherwise 200 OK.
+// ParamError.UserErr from apiErrResponse is available for per-error override if needed in future.
+func apiErrResponse(c echo.Context, err error, status int, userMsg string) error {
+	log.Error(err.Error())
+	if EnableUserAPIErr {
+		return c.JSON(status, echo.Map{"status": "error", "message": userMsg})
+	}
+	return c.JSON(http.StatusOK, echo.Map{})
 }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Currently UI does not have any way to show User facing error, additionally sanitation changes need to be concluded on by stake holders in order to enable the same from backend.

The sanitation logic is present but has been disabled for all query params.

Note: Pre-existing error responses for container endpoints has not been handed in this PR.

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Gate user-facing API error responses behind a central toggle while disabling sanitization checks for all query parameters.

Bug Fixes:
- Standardize error handling for recommendation and namespace list endpoints via a common API error response helper that logs errors and conditionally returns user messages.

Enhancements:
- Introduce a configurable flag to skip sanitization for container and namespace query parameters while wiring this through the query filter builder pipeline.
- Add a global switch controlling whether detailed user-facing error messages are returned or suppressed, centralizing this logic in a shared apiErrResponse helper.
- Refine ParamError to better distinguish internal application errors from user-visible flags without changing its external error interface.
- Adjust query parameter validation to rely on the global user error toggle instead of per-error user visibility flags.
- Relax tests for query parameter length validation where sanitization is now disabled, and update handler tests to account for the conditional error response behavior.