### PR TITLE
[FLPATH-3318] Bind Kafka SASL/TLS env vars in non-Clowder config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -174,6 +174,13 @@ func initConfig() {
 		viper.SetDefault("RECOMMENDATION_TOPIC", "rosocp.kruize.recommendations")
 		viper.SetDefault("SOURCES_EVENT_TOPIC", "platform.sources.event-stream")
 
+		// Kafka SASL/TLS config (env vars set by Helm chart when kafka.sasl is configured)
+		_ = viper.BindEnv("KafkaSecurityProtocol", "KAFKA_SECURITY_PROTOCOL")
+		_ = viper.BindEnv("KafkaSASLMechanism", "KAFKA_SASL_MECHANISM")
+		_ = viper.BindEnv("KafkaUsername", "KAFKA_SASL_USERNAME")
+		_ = viper.BindEnv("KafkaPassword", "KAFKA_SASL_PASSWORD")
+		_ = viper.BindEnv("KafkaCA", "KAFKA_SSL_CA_LOCATION")
+
 		// DB Config
 		_ = viper.BindEnv("DBHost", "DB_HOST")
 		viper.SetDefault("DBHost", "localhost")


### PR DESCRIPTION
## Summary

- Add `viper.BindEnv` calls for `KafkaSecurityProtocol`, `KafkaSASLMechanism`, `KafkaUsername`, `KafkaPassword`, and `KafkaCA` in the non-Clowder config branch
- The Clowder path already populates these fields from `cdappconfig.json`; this enables the on-prem Helm chart to pass SASL/TLS settings via standard `KAFKA_*` environment variables

The existing consumer/producer code in `internal/kafka/` already checks `KafkaSASLMechanism != ""` and applies `security.protocol`, `sasl.*`, `ssl.ca.location` — only the non-Clowder config wiring was missing.

### Companion PRs

- **Helm chart**: https://github.com/insights-onprem/cost-onprem-chart/pull/162 — wires `KAFKA_SASL_*` env vars into ROS pods
- **Koku**: https://github.com/project-koku/koku/pull/6047 — `EnvConfigurator` reads `KAFKA_SASL_*` env vars

## Test plan

- [x] Existing consumer/producer SASL branching logic is unchanged
- [x] New `viper.BindEnv` calls match the env var names used by the Helm chart
- [x] Integration: deploy with Strimzi SASL_SSL listener and verify ROS connects

## Summary by Sourcery

Enhancements:
- Wire Kafka SASL/TLS configuration fields to corresponding KAFKA_* environment variables for non-Clowder deployments.