### PR TITLE
Updated Kruize image tag for release 0.10

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "d2d9cef"
+  value: "bd937f6"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d2d9cef
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:bd937f6
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## PR Title :boom:

Updated Kruize image tag for release 0.10

## Summary by Sourcery

Build:
- Bump the KRUIZE_IMAGE_TAG parameter and Docker image tag from d2d9cef to bd937f6 for the Kruize autotune service.