### PR TITLE
RHINENG-26091 Numeric consistency between JSON and CSV responses

### DIFF
--- a/internal/api/utils.go
+++ b/internal/api/utils.go
@@ -950,25 +950,23 @@ func UpdateRecommendationJSON(handlerName string, recommendationID string, clust
 	return data
 }
 
-func formatPrecisionValuesToStr(val float64) string {
-	// avoid un-necessary rounding by sprintf 104.939886 -> -104.940
-	multiplier := 1000.0
-	truncatedVal := math.Trunc(val*multiplier) / multiplier
-
-	s := fmt.Sprintf("%.3f", truncatedVal)
-	s = strings.TrimRight(s, "0")  // removes trailing zeros
-	s = strings.TrimSuffix(s, ".") // removes trailing "." for instance 10.0
-	return s
-}
-
 func GenerateCSVRows(recommendationSet model.RecommendationSetResult) ([][]string, error) {
 	rows := [][]string{}
 	variationFormat := "percent"
 	var recommendationObj kruizePayload.RecommendationData
-	err := json.Unmarshal([]byte(recommendationSet.Recommendations), &recommendationObj)
+
+	if recommendationSet.RecommendationsJSON == nil {
+		return nil, fmt.Errorf("RecommendationsJSON not set for %s: call UpdateRecommendationJSON first", recommendationSet.ID)
+	}
+	b, err := json.Marshal(recommendationSet.RecommendationsJSON)
 	if err != nil {
+		return nil, fmt.Errorf("unable to marshal RecommendationsJSON %s: %w", recommendationSet.ID, err)
+	}
+	if err := json.Unmarshal(b, &recommendationObj); err != nil {
 		return nil, fmt.Errorf("unable to unmarshall recommendation %s: %w", recommendationSet.ID, err)
 	}
+
+	f := func(v float64) string { return strconv.FormatFloat(v, 'f', -1, 64) }
 
 	type namedTerm struct {
 		name string
@@ -998,26 +996,6 @@ func GenerateCSVRows(recommendationSet model.RecommendationSetResult) ([][]strin
 		for _, ne := range orderedEngines {
 			recommendationType := ne.name
 			recommendationEngine := ne.engine
-
-			variationCPULimitPercentage := utils.VariationPercentOfRequestCPU(
-				recommendationEngine.Variation.Limits.Cpu.Amount,
-				recommendationObj.Current.Limits.Cpu.Amount,
-			)
-
-			variationMemoryLimitPercentage := utils.VariationPercentOfRequestMemoryBytesMiB(
-				recommendationEngine.Variation.Limits.Memory.Amount,
-				recommendationObj.Current.Limits.Memory.Amount,
-			)
-
-			variationCPURequestPercentage := utils.VariationPercentOfRequestCPU(
-				recommendationEngine.Variation.Requests.Cpu.Amount,
-				recommendationObj.Current.Requests.Cpu.Amount,
-			)
-
-			variationMemoryRequestPercentage := utils.VariationPercentOfRequestMemoryBytesMiB(
-				recommendationEngine.Variation.Requests.Memory.Amount,
-				recommendationObj.Current.Requests.Memory.Amount,
-			)
 			rows = append(rows, []string{
 				recommendationSet.ID,
 				recommendationSet.ClusterUUID,
@@ -1028,34 +1006,34 @@ func GenerateCSVRows(recommendationSet model.RecommendationSetResult) ([][]strin
 				recommendationSet.WorkloadType,
 				recommendationSet.LastReported,
 				recommendationSet.SourceID,
-				formatPrecisionValuesToStr(convertCPUUnit("cores", recommendationObj.Current.Limits.Cpu.Amount)),
+				f(recommendationObj.Current.Limits.Cpu.Amount),
 				recommendationObj.Current.Limits.Cpu.Format,
-				fmt.Sprint(recommendationObj.Current.Limits.Memory.Amount),
+				f(recommendationObj.Current.Limits.Memory.Amount),
 				recommendationObj.Current.Limits.Memory.Format,
-				formatPrecisionValuesToStr(convertCPUUnit("cores", recommendationObj.Current.Requests.Cpu.Amount)),
+				f(recommendationObj.Current.Requests.Cpu.Amount),
 				recommendationObj.Current.Requests.Cpu.Format,
-				fmt.Sprint(recommendationObj.Current.Requests.Memory.Amount),
+				f(recommendationObj.Current.Requests.Memory.Amount),
 				recommendationObj.Current.Requests.Memory.Format,
 				recommendationObj.MonitoringEndTime.String(),
 				termName,
-				fmt.Sprint(recommendationTerm.DurationInHours),
+				f(recommendationTerm.DurationInHours),
 				recommendationTerm.MonitoringStartTime.String(),
 				recommendationType,
-				formatPrecisionValuesToStr(convertCPUUnit("cores", recommendationEngine.Config.Limits.Cpu.Amount)),
+				f(recommendationEngine.Config.Limits.Cpu.Amount),
 				recommendationEngine.Config.Limits.Cpu.Format,
-				fmt.Sprint(recommendationEngine.Config.Limits.Memory.Amount),
+				f(recommendationEngine.Config.Limits.Memory.Amount),
 				recommendationEngine.Config.Limits.Memory.Format,
-				formatPrecisionValuesToStr(convertCPUUnit("cores", recommendationEngine.Config.Requests.Cpu.Amount)),
+				f(recommendationEngine.Config.Requests.Cpu.Amount),
 				recommendationEngine.Config.Requests.Cpu.Format,
-				fmt.Sprint(recommendationEngine.Config.Requests.Memory.Amount),
+				f(recommendationEngine.Config.Requests.Memory.Amount),
 				recommendationEngine.Config.Requests.Memory.Format,
-				formatPrecisionValuesToStr(variationCPULimitPercentage),
+				f(recommendationEngine.Variation.Limits.Cpu.Amount),
 				variationFormat,
-				fmt.Sprint(variationMemoryLimitPercentage),
+				f(recommendationEngine.Variation.Limits.Memory.Amount),
 				variationFormat,
-				formatPrecisionValuesToStr(variationCPURequestPercentage),
+				f(recommendationEngine.Variation.Requests.Cpu.Amount),
 				variationFormat,
-				fmt.Sprint(variationMemoryRequestPercentage),
+				f(recommendationEngine.Variation.Requests.Memory.Amount),
 				variationFormat,
 			})
 		}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -10,6 +12,11 @@ import (
 )
 
 func float64Ptr(v float64) *float64 { return &v }
+
+func prepareRec(rs model.RecommendationSetResult) model.RecommendationSetResult {
+	rs.RecommendationsJSON = UpdateRecommendationJSON("", "", "", map[string]string{"cpu": "cores", "memory": "bytes"}, false, rs.Recommendations, &model.StoredVariationPcts{})
+	return rs
+}
 
 // Minimal recommendation JSON that exercises both term and engine maps.
 // short_term has cost + performance engines; medium_term has cost only.
@@ -53,7 +60,7 @@ const testRecommendationJSON = `{
 }`
 
 func TestGenerateCSVRows_DeterministicOrder(t *testing.T) {
-	rec := model.RecommendationSetResult{
+	rec := prepareRec(model.RecommendationSetResult{
 		ID:              "test-id",
 		ClusterUUID:     "cluster-uuid",
 		ClusterAlias:    "cluster-alias",
@@ -64,7 +71,7 @@ func TestGenerateCSVRows_DeterministicOrder(t *testing.T) {
 		LastReported:    "2024-01-15",
 		SourceID:        "src-1",
 		Recommendations: datatypes.JSON(testRecommendationJSON),
-	}
+	})
 
 	first, err := GenerateCSVRows(rec)
 	if err != nil {
@@ -86,7 +93,7 @@ func TestGenerateCSVRows_DeterministicOrder(t *testing.T) {
 }
 
 func TestGenerateCSVRows_TermOrdering(t *testing.T) {
-	rec := model.RecommendationSetResult{
+	rec := prepareRec(model.RecommendationSetResult{
 		ID:              "test-id",
 		ClusterUUID:     "cluster-uuid",
 		ClusterAlias:    "cluster-alias",
@@ -97,7 +104,7 @@ func TestGenerateCSVRows_TermOrdering(t *testing.T) {
 		LastReported:    "2024-01-15",
 		SourceID:        "src-1",
 		Recommendations: datatypes.JSON(testRecommendationJSON),
-	}
+	})
 
 	rows, err := GenerateCSVRows(rec)
 	if err != nil {
@@ -197,4 +204,34 @@ func TestInjectStoredRequestVariationPct(t *testing.T) {
 			t.Fatalf("memory format: got %v, want bytes", got)
 		}
 	})
+}
+
+// TestJSONvsCSVCPULimitAmount verifies that current_cpu_limit_amount is identical in
+// JSON and CSV for boundary float64 values (e.g. 2.034 = 2.033999... in IEEE 754).
+func TestJSONvsCSVCPULimitAmount(t *testing.T) {
+	for _, amount := range []float64{2.034, 1.0, 0.5, 2.1, 10.999, 0.001, 0.064, 100.123, 0.333, 7.0} {
+		rec := fmt.Sprintf(`{
+			"current": {
+				"limits":   {"cpu": {"amount": %v}},
+				"requests": {"cpu": {}}
+			},
+			"recommendation_terms": {
+				"short_term": {"recommendation_engines": {"cost": {"config": {}, "variation": {}}}}
+			}
+		}`, amount)
+
+		rs := prepareRec(model.RecommendationSetResult{Recommendations: datatypes.JSON(rec)})
+
+		jsonCPU := rs.RecommendationsJSON["current"].(map[string]interface{})["limits"].(map[string]interface{})["cpu"].(map[string]interface{})
+		jsonAmount := strconv.FormatFloat(jsonCPU["amount"].(float64), 'f', -1, 64)
+
+		rows, err := GenerateCSVRows(rs)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if rows[0][9] != jsonAmount {
+			t.Errorf("amount=%v: CPU limit mismatch: csv=%q json=%q", amount, rows[0][9], jsonAmount)
+		}
+	}
 }


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Since the numbers were being re-calculated for csv there were some precision mismatches.
Numbers from json response are now being used for CSV.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Ensure CSV recommendations reuse the same JSON-derived numeric values to maintain precision consistency between response formats.

Bug Fixes:
- Align CSV numeric fields with their JSON counterparts to avoid precision mismatches in recommendation data.

Enhancements:
- Refactor CSV generation to read from pre-parsed RecommendationsJSON and use consistent float-to-string formatting across outputs.

Tests:
- Add regression test to verify CPU limit values in CSV exactly match those in the JSON for various boundary float64 values.
- Update existing CSV generation tests to construct recommendations via the JSON update path.