### PR TITLE
RHINENG-26485 Fix Unleash config overwrite

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -211,7 +211,7 @@ func initConfig() {
 
 		// Unleash config
 		viper.SetDefault("UnleashClientAccessToken", "rosocp:dev.token")
-		viper.SetDefault("UnleashHostname", "0.0.0.0")
+		viper.SetDefault("UnleashHostname", "localhost")
 		viper.SetDefault("UnleashScheme", "http")
 		viper.SetDefault("UnleashPort", 3063)
 		viper.SetDefault(

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -208,6 +208,20 @@ func initConfig() {
 
 		// Sources-api-go
 		viper.SetDefault("SOURCES_API_BASE_URL", "http://127.0.0.1:8002")
+
+		// Unleash config
+		viper.SetDefault("UnleashClientAccessToken", "rosocp:dev.token")
+		viper.SetDefault("UnleashHostname", "0.0.0.0")
+		viper.SetDefault("UnleashScheme", "http")
+		viper.SetDefault("UnleashPort", 3063)
+		viper.SetDefault(
+			"UnleashFullURL",
+			fmt.Sprintf(
+				"%s://%s:%d/api/",
+				viper.GetString("UnleashScheme"),
+				viper.GetString("UnleashHostname"),
+				viper.GetInt("UnleashPort")),
+		)
 	}
 
 	viper.SetDefault("SOURCES_API_PREFIX", "/api/sources/v3.1")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,20 +245,6 @@ func initConfig() {
 	viper.SetDefault("MAXIMUM_COUNT_PER_QUERY_PARAM", 5)
 	viper.SetDefault("GLOBAL_HTTP_CLIENT_TIMEOUT_SECS", 30)
 
-	// Unleash config
-	viper.SetDefault("UnleashClientAccessToken", "rosocp:dev.token")
-	viper.SetDefault("UnleashHostname", "0.0.0.0")
-	viper.SetDefault("UnleashScheme", "http")
-	viper.SetDefault("UnleashPort", 3063)
-	viper.SetDefault(
-		"UnleashFullURL",
-		fmt.Sprintf(
-			"%s://%s:%d/api/",
-			viper.GetString("UnleashScheme"),
-			viper.GetString("UnleashHostname"),
-			viper.GetInt("UnleashPort")),
-	)
-
 	// Hack till viper issue get fix - https://github.com/spf13/viper/issues/761
 	envKeysMap := &map[string]interface{}{}
 	if err := mapstructure.Decode(cfg, &envKeysMap); err != nil {


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Unleash Clowder config was getting overwritten by local, since it was present outside the else block.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Changes tested locally i.e. non-EE with Kruize 0.10 and performance profile v2, able to see namespace and container recommendations.