### PR TITLE
RHINENG-26482 Set default memory format to bytes

### DIFF
--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -207,7 +207,7 @@ func GetNamespaceRecommendationSet(c echo.Context) error {
 		return apiErrResponse(c, err, http.StatusBadRequest, "bad recommendation-id for project")
 	}
 
-	unitChoices, setk8sUnits, unitParseErr := ParseUnitParams(c, "cores", "MiB")
+	unitChoices, setk8sUnits, unitParseErr := ParseUnitParams(c, "cores", "bytes")
 	if unitParseErr != nil {
 		return apiErrResponse(c, unitParseErr, http.StatusBadRequest, unitParseErr.Error())
 	}

--- a/internal/api/utils_test.go
+++ b/internal/api/utils_test.go
@@ -235,3 +235,38 @@ func TestJSONvsCSVCPULimitAmount(t *testing.T) {
 		}
 	}
 }
+
+func TestMemoryBytesPreserved(t *testing.T) {
+	/*
+		Generic memory format test;
+		TODO: Set default format to bytes for Container detail endpoint later
+	*/
+
+	const nsRecJSON = `{
+		"current": {
+			"limits":   {"cpu": {"amount": 0.5, "format": "cores"}, "memory": {"amount": 536870912, "format": "bytes"}},
+			"requests": {"cpu": {"amount": 0.25, "format": "cores"}, "memory": {"amount": 268435456, "format": "bytes"}}
+		},
+		"recommendation_terms": {}
+	}`
+
+	result := UpdateRecommendationJSON(
+		"namespace-recommendationset", "", "",
+		map[string]string{"cpu": "cores", "memory": "bytes"}, false,
+		datatypes.JSON(nsRecJSON), &model.StoredVariationPcts{},
+	)
+
+	current := result["current"].(map[string]interface{})
+	for _, section := range []string{"limits", "requests"} {
+		mem := current[section].(map[string]interface{})["memory"].(map[string]interface{})
+		if mem["format"] != "bytes" {
+			t.Errorf("current.%s.memory.format: got %q, want \"bytes\"", section, mem["format"])
+		}
+	}
+	if got := current["limits"].(map[string]interface{})["memory"].(map[string]interface{})["amount"].(float64); got != 536870912 {
+		t.Errorf("current.limits.memory.amount: got %v, want 536870912", got)
+	}
+	if got := current["requests"].(map[string]interface{})["memory"].(map[string]interface{})["amount"].(float64); got != 268435456 {
+		t.Errorf("current.requests.memory.amount: got %v, want 268435456", got)
+	}
+}


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:


Set default memory format to bytes for Namespace Recommendation detail endpoint

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Set the namespace recommendation detail endpoint to use bytes as the default memory unit and add coverage to ensure this behavior is preserved.

Enhancements:
- Change the default memory unit for namespace recommendation responses from MiB to bytes.

Tests:
- Add a unit test verifying that memory recommendations retain the bytes format and expected amounts.