### PR TITLE
Revert usage of KruizePerformanceProfileVersion on Kruize API calls

### DIFF
--- a/internal/types/kruizePayload/createExperiment.go
+++ b/internal/types/kruizePayload/createExperiment.go
@@ -34,7 +34,7 @@ func GetCreateExperimentPayload(experiment_name string, cluster_identifier strin
 	}
 	payload := []createExperiment{
 		{
-			Version:                 "1.0", // TODO To be set to cfg.KruizePerformanceProfileVersion
+			Version:                 "1.0",
 			Experiment_name:         experiment_name,
 			Cluster_name:            cluster_identifier,
 			Performance_profile:     "resource-optimization-openshift",

--- a/internal/types/kruizePayload/namespace/createExperiment.go
+++ b/internal/types/kruizePayload/namespace/createExperiment.go
@@ -1,7 +1,6 @@
 package namespace
 
 import (
-	"github.com/redhatinsights/ros-ocp-backend/internal/config"
 	kruizePayload "github.com/redhatinsights/ros-ocp-backend/internal/types/kruizePayload"
 )
 
@@ -19,10 +18,9 @@ type CreateNamespaceExperiment struct {
 }
 
 func GetCreateNamespaceExperimentPayload(experiment_name string, cluster_identifier string, namespace string) []CreateNamespaceExperiment {
-	cfg := config.GetConfig()
 	return []CreateNamespaceExperiment{
 		{
-			Version:            cfg.KruizePerformanceProfileVersion,
+			Version:            "1.0",
 			ExperimentName:     experiment_name,
 			ClusterName:        cluster_identifier,
 			PerformanceProfile: "resource-optimization-openshift",

--- a/internal/types/kruizePayload/namespace/updateResult.go
+++ b/internal/types/kruizePayload/namespace/updateResult.go
@@ -2,7 +2,6 @@ package namespace
 
 import (
 	"github.com/go-gota/gota/dataframe"
-	"github.com/redhatinsights/ros-ocp-backend/internal/config"
 	"github.com/redhatinsights/ros-ocp-backend/internal/logging"
 	"github.com/redhatinsights/ros-ocp-backend/internal/types"
 	kruizePayload "github.com/redhatinsights/ros-ocp-backend/internal/types/kruizePayload"
@@ -27,8 +26,6 @@ type UpdateNamespaceResult struct {
 }
 
 func GetUpdateNamespaceResultPayload(experiment_name string, namespaceData []map[string]any) []UpdateNamespaceResult {
-	cfg := config.GetConfig()
-
 	log := logging.GetLogger()
 	payload := []UpdateNamespaceResult{}
 	df := dataframe.LoadMaps(
@@ -54,7 +51,7 @@ func GetUpdateNamespaceResultPayload(experiment_name string, namespaceData []map
 		metrics := makeNamespaceMetrics(row)
 
 		payload = append(payload, UpdateNamespaceResult{
-			Version:           cfg.KruizePerformanceProfileVersion,
+			Version:           "1.0",
 			ExperimentName:    experiment_name,
 			IntervalStartTime: intervalStart,
 			IntervalEndTime:   intervalEnd,

--- a/internal/types/kruizePayload/updateResult.go
+++ b/internal/types/kruizePayload/updateResult.go
@@ -70,7 +70,7 @@ func GetUpdateResultPayload(experiment_name string, containers []map[string]inte
 			container_array = append(container_array, make_container_data(c))
 		}
 		payload = append(payload, UpdateResult{
-			Version:             "1.0", // TODO To be set to cfg.KruizePerformanceProfileVersion
+			Version:             "1.0",
 			Experiment_name:     experiment_name,
 			Interval_start_time: data["interval_start"],
 			Interval_end_time:   data["interval_end"],


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

The version on UpdateResults and CreateExperiments in not the performance profile version.
Thread [here](https://github.com/RedHatInsights/ros-ocp-backend/pull/475#discussion_r3275251729).
We still need cfg.KruizePerformanceProfileVersion for the Update performance profile feature.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Bug Fixes:
- Correct the version field sent in Kruize create experiment and update result namespace/container payloads to use the API version rather than the performance profile version.