### PR TITLE
RHINENG-25816 Update PostgreSQL version to 16

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -229,7 +229,7 @@ objects:
 
     database:
       name: rosocp
-      version: 13
+      version: 16
     kafkaTopics:
       - topicName: hccm.ros.events
         partitions: 1

--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -216,7 +216,7 @@ objects:
               value: "false"
     database:
       name: postgres
-      version: 13
+      version: 16
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdJobInvocation

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - kafka
 
   db-ros:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
@@ -40,7 +40,7 @@ services:
       - "15432:5432"
 
   db-kruize:
-    image: postgres
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres
@@ -103,7 +103,7 @@ services:
       - 8888:80
 
   db-sources:
-    image: postgres:14
+    image: postgres:16
     restart: always
     environment:
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Resolves [RHINENG-25816](https://redhat.atlassian.net/browse/RHINENG-25816). Update the DB versionto ensure consistency.

## Documentation update? :memo:

- [ ] Yes
- [X] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

[RHINENG-25816]: https://redhat.atlassian.net/browse/RHINENG-25816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Summary by Sourcery

Update PostgreSQL to version 16 across local Docker services and Clowder database configurations for ROS and Kruize components.

Build:
- Bump PostgreSQL Docker images in docker-compose services to use postgres:16 for ROS, Kruize, and sources databases.

Deployment:
- Update ClowdApp database configurations to use PostgreSQL version 16 for rosocp and Kruize deployments.