### PR TITLE
RHINENG-26598 Enable Namespace recommendations on Stage

### DIFF
--- a/clowdapp.yaml
+++ b/clowdapp.yaml
@@ -311,6 +311,6 @@ parameters:
   value: 'INFO'
 - description: Disable namespace recommendations feature
   name: DISABLE_NAMESPACE_RECOMMENDATION
-  value: "true"
+  value: "false"
 - name: PARTITION_DELETE_INTERVAL
   value: "0 0 */15 * *" # Runs at 12:00 AM, every 15 days.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -242,7 +242,7 @@ func initConfig() {
 	viper.SetDefault("READ_HEADER_TIMEOUT", 15)
 	viper.SetDefault("RECORD_LIMIT_CSV", 1000)
 	viper.SetDefault("CSV_STREAM_INTERVAL", 100)
-	viper.SetDefault("DISABLE_NAMESPACE_RECOMMENDATION", true)
+	viper.SetDefault("DISABLE_NAMESPACE_RECOMMENDATION", false)
 	viper.SetDefault("MAXIMUM_COUNT_PER_QUERY_PARAM", 5)
 	viper.SetDefault("GLOBAL_HTTP_CLIENT_TIMEOUT_SECS", 30)
 	viper.SetDefault("UPDATE_KRUIZE_PERF_PROFILE", true)

--- a/internal/featureflags/flags.go
+++ b/internal/featureflags/flags.go
@@ -1,13 +1,20 @@
 package featureflags
 
 import (
+	"sync"
+
 	"github.com/Unleash/unleash-go-sdk/v5"
 	"github.com/Unleash/unleash-go-sdk/v5/context"
 )
 
+var namespaceRecommendationDisabledOnce sync.Once
+
 func IsNamespaceEnabled(org_id string) bool {
 	if cfg.DisableNamespaceRecommendation {
-		log.Warn("namespace recommendation feature disabled application-wide")
+		// warn once per pod lifecycle
+		namespaceRecommendationDisabledOnce.Do(func() {
+			log.Warn("namespace recommendation feature disabled application-wide")
+		})
 		return false
 	}
 

--- a/internal/featureflags/flags.go
+++ b/internal/featureflags/flags.go
@@ -7,8 +7,7 @@ import (
 
 func IsNamespaceEnabled(org_id string) bool {
 	if cfg.DisableNamespaceRecommendation {
-		// TODO Set logger with Warn after feature deployment
-		log.Debug("namespace recommendation feature disabled application-wide")
+		log.Warn("namespace recommendation feature disabled application-wide")
 		return false
 	}
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Config changes to enable Namespace recommendations on Stage


## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Requires manual flag creation in the Unleash stage instance with orgID as the constraint.

## Summary by Sourcery

Enable namespace recommendation feature by default in stage and improve feature flag logging.

New Features:
- Turn on namespace recommendations by default via configuration and Clowder parameters.

Enhancements:
- Log a single warning per pod lifecycle when namespace recommendations are globally disabled instead of repeatedly logging debug messages.