### PR TITLE
RHINENG-20625 Add gosec linter and address existing warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,9 +9,16 @@ linters:
     - unused
     - unparam
     - govet
+    - gosec
+    # TODO: enable gocritic with performance tag
+    # - gocritic
   settings:
+    # gocritic:
+    #   disable-all: true
+    #   enabled-tags:
+    #     - performance
     errcheck:
-        exclude-functions:
+      exclude-functions:
         - fmt.Fprintln
         - fmt.Fprint
 

--- a/cmd/aggregator.go
+++ b/cmd/aggregator.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/go-gota/gota/dataframe"
 	"github.com/spf13/cobra"
@@ -26,7 +27,7 @@ var (
 			}
 			if outputDir != "" {
 				if _, err := os.Stat(outputDir); os.IsNotExist(err) {
-					if err := os.MkdirAll(outputDir, os.ModePerm); err != nil {
+					if err := os.MkdirAll(outputDir, 0750); err != nil {
 						panic(err.Error())
 					}
 				}
@@ -34,7 +35,7 @@ var (
 				outputDir, _ = os.Getwd()
 			}
 			outputFile := outputDir + "/output.csv"
-			f, err := os.Open(input_file)
+			f, err := os.Open(filepath.Clean(input_file))
 			if err != nil {
 				panic(err.Error())
 			}
@@ -54,7 +55,7 @@ var (
 			if err != nil {
 				panic(err.Error())
 			}
-			fileio, err := os.Create(outputFile)
+			fileio, err := os.Create(filepath.Clean(outputFile))
 			if err != nil {
 				panic(err.Error())
 			}

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
-	github.com/prometheus/common v0.68.1 // indirect
+	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect
 	github.com/sagikazarmark/locafero v0.12.0 // indirect
 	github.com/spf13/afero v1.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.68.1 h1:omjRRl4QP4komogpXuhfeOiisQg7xdy8VM1UY+pStaY=
-github.com/prometheus/common v0.68.1/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
+github.com/prometheus/common v0.69.0 h1:OA85nJQS/T/MaYh/Q2CcgDKSGWqNIgrBDvDH85CuiNk=
+github.com/prometheus/common v0.69.0/go.mod h1:ZzL3f6u94qUxh9p+tJTrF+FvBS1XXbbRAZCQkytAL0Y=
 github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEycfc=
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/redhatinsights/app-common-go v1.6.9 h1:juGobZnDvMqpx6DAO2qq9aFk/g93MblQQVVPPwTAfdM=

--- a/internal/types/kruizePayload/namespace/namespace_test.go
+++ b/internal/types/kruizePayload/namespace/namespace_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestUnmarshalCreateNamespaceExperiment(t *testing.T) {
 	jsonPath := filepath.Join("..", "..", "..", "..", "scripts", "samples", "namespace_create_experiment.json")
-	createExperimentJSON, err := os.ReadFile(jsonPath)
+	createExperimentJSON, err := os.ReadFile(filepath.Clean(jsonPath))
 	if err != nil {
 		t.Fatalf("failed to read JSON file: %v", err)
 	}
@@ -72,7 +72,7 @@ func TestUnmarshalCreateNamespaceExperiment(t *testing.T) {
 
 func TestUnmarshalNamespaceUpdateResult(t *testing.T) {
 	jsonPath := filepath.Join("..", "..", "..", "..", "scripts", "samples", "namespace_update_result.json")
-	updateResultJSON, err := os.ReadFile(jsonPath)
+	updateResultJSON, err := os.ReadFile(filepath.Clean(jsonPath))
 	if err != nil {
 		t.Fatalf("failed to read JSON file: %v", err)
 	}
@@ -107,7 +107,7 @@ func TestUnmarshalNamespaceUpdateResult(t *testing.T) {
 
 func TestUnmarshalNamespaceRecommendationResponse(t *testing.T) {
 	jsonPath := filepath.Join("..", "..", "..", "..", "scripts", "samples", "namespace_recommendation.json")
-	recommendationJSON, err := os.ReadFile(jsonPath)
+	recommendationJSON, err := os.ReadFile(filepath.Clean(jsonPath))
 	if err != nil {
 		t.Fatalf("failed to read JSON file: %v", err)
 	}

--- a/internal/utils/kruize/kruize_api.go
+++ b/internal/utils/kruize/kruize_api.go
@@ -162,7 +162,7 @@ func Update_results(experiment_name string, payload_data []kruizePayload.UpdateR
 	// TODO(FLPATH-3407): use a bounded client once we have Prometheus latency data for /updateResults
 	url := cfg.KruizeUrl + KruizeUpdateResults
 	log.Debugf("\n Sending /updateResult request to kruize with payload - %s \n", string(postBody))
-	res, err := http.Post(url, "application/json", bytes.NewBuffer(postBody))
+	res, err := http.Post(url, "application/json", bytes.NewBuffer(postBody)) //nolint:gosec // URL from trusted config
 	if err != nil {
 		kruizeAPIException.WithLabelValues(KruizeUpdateResults).Inc()
 		return nil, fmt.Errorf("an Error Occured while sending metrics: %v", err)
@@ -214,7 +214,7 @@ func UpdateNamespaceResults(experiment_name string, payload_data []namespacePayl
 	// TODO(FLPATH-3407): use a bounded client once we have Prometheus latency data for /updateResults
 	url := cfg.KruizeUrl + KruizeUpdateResults
 	log.Debugf("\n Sending /updateResult request to kruize with namespace payload - %s \n", string(postBody))
-	res, err := http.Post(url, "application/json", bytes.NewBuffer(postBody))
+	res, err := http.Post(url, "application/json", bytes.NewBuffer(postBody)) //nolint:gosec // URL from trusted config
 	if err != nil {
 		kruizeAPIException.WithLabelValues(KruizeUpdateResults).Inc()
 		return nil, fmt.Errorf("an Error Occured while sending namespace metrics: %v", err)

--- a/internal/utils/sources/sources_api.go
+++ b/internal/utils/sources/sources_api.go
@@ -14,7 +14,7 @@ var cfg *config.Config = config.GetConfig()
 
 func GetCostApplicationID() (int, error) {
 	url := cfg.SourceApiBaseUrl + cfg.SourceApiPrefix + "/application_types?filter[name][eq]=/insights/platform/cost-management"
-	res, err := http.Get(url)
+	res, err := http.Get(url) //nolint:gosec // URL from trusted config
 	if err != nil {
 		return 0, fmt.Errorf("error while calling sources API: %v", err)
 	}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -307,12 +308,7 @@ func GenerateNamespaceExperimentName(org_id, source_id, cluster_id, namespace st
 }
 
 func StringInSlice(a string, list []string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(list, a)
 }
 
 func Start_prometheus_server() {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -185,9 +186,10 @@ func SetupKruizePerformanceProfile() {
 
 }
 
-func ReadCSVFromUrl(url string) ([][]string, error) {
+func ReadCSVFromUrl(csvURL string) ([][]string, error) {
 	// TODO(FLPATH-3407): use a bounded client once we have latency data for CSV downloads
-	resp, err := http.Get(url)
+	parsedCSVURL, _ := url.Parse(csvURL)
+	resp, err := http.Get(parsedCSVURL.String())
 	if err != nil {
 		return nil, err
 	}
@@ -196,7 +198,7 @@ func ReadCSVFromUrl(url string) ([][]string, error) {
 	}()
 
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, fmt.Errorf("unexpected status code %d when fetching CSV from %s", resp.StatusCode, url)
+		return nil, fmt.Errorf("unexpected status code %d when fetching CSV from %s", resp.StatusCode, csvURL)
 	}
 
 	reader := csv.NewReader(resp.Body)
@@ -317,7 +319,11 @@ func Start_prometheus_server() {
 	if cfg.PrometheusPort != "" {
 		log.Info("Starting prometheus http server")
 		http.Handle("/metrics", promhttp.Handler())
-		_ = http.ListenAndServe(fmt.Sprintf(":%s", cfg.PrometheusPort), nil)
+		s := &http.Server{
+			Addr:              fmt.Sprintf(":%s", cfg.PrometheusPort),
+			ReadHeaderTimeout: time.Duration(cfg.ReadHeaderTimeout) * time.Second,
+		}
+		_ = s.ListenAndServe()
 	}
 }
 


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Addressed gosec warnings from existing code base and added the linter.

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [x] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

NA

## Summary by Sourcery

Introduce security-focused linting and adjust code to address gosec findings across utilities, CLI, and API integrations.

New Features:
- Enable gosec linter in golangci-lint configuration for security scanning.

Bug Fixes:
- Validate and format CSV download URLs before issuing HTTP requests to reduce potential misuse.

Enhancements:
- Harden file path handling using filepath.Clean in CLI commands and tests.
- Improve HTTP server initialization for Prometheus metrics with configurable header read timeout.
- Refactor string containment helper to use standard library slices.Contains.
- Tighten directory creation permissions for aggregator output directories.

Build:
- Update golangci-lint configuration to include gosec and prepare for future gocritic performance checks.
- Bump indirect dependency github.com/prometheus/common to v0.69.0.

Tests:
- Use cleaned file paths when reading JSON fixtures in namespace payload tests to align with hardened file handling.

Chores:
- Annotate trusted HTTP calls with gosec suppression comments to document intentional usage of dynamic URLs.