### PR TITLE
RHINENG-26870 Upgrade Kruize image to 0.11

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "bd937f6"
+  value: "c1eaa66"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:bd937f6
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:c1eaa66
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no: Kruize 0.11
  - [ ] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Build:
- Update Kruize image tag parameter and docker-compose service to use the c1eaa66 autotune image.