### PR TITLE
RHINENG-26870 Rollback Kruize image to v0.10

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "c1eaa66"
+  value: "bd937f6"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:c1eaa66
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:bd937f6
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

- Kruize v0.11 is crashlooping on Openshift

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Does this change depend on specific version of Kruize
  - If yes what is the version no: Set Kruize v0.10 for repo
  - [x] Is that image available in production or needs deployment? Prod downgrade has already been handled.
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

NA

## Summary by Sourcery

Roll back the Kruize deployment to a previous image tag across deployment templates and local docker-compose configuration.

Build:
- Update Kruize image tag parameter in the clowdapp template to use the bd937f6 image instead of c1eaa66.

Deployment:
- Align the docker-compose kruize-autotune service image tag with the rolled-back bd937f6 image.