### PR TITLE
Update Kruize image tag corresponding to 0.11.1

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "bd937f6"
+  value: "d1f0140"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:bd937f6
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d1f0140
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## PR Title :boom:

This PR updates kruize image tag in docker and clowdapp files corresponding to the latest kruize release.

**Note**: There are no changes in code, changes made are only in dockerFile, tests and docs. Apart from this there is a fix for `netty-resolver-dns` which is indirectly used in one of our packages in `pom.xml` to address a CVE.

### How ClowdWatch Fix Was Tested

#### 1. Unit tests — automated, no cluster needed

**`src/test/java/com/autotune/utils/CloudWatchAppenderTest.java`**

Six tests covering the credential-guard logic and `jdk.net` module availability:

| Test | What it validates |
|------|------------------|
| `shouldSkipConfigurationWhenAllCredentialsAreNull` | Guard fires when all credentials are `null` — no appender registered, no crash |
| `shouldSkipConfigurationWhenCredentialsAreEmpty` | Guard fires when credentials are empty strings |
| `shouldSkipConfigurationWhenAccessKeyIdIsMissing` | Guard fires when only one credential is missing |
| `jdkNetModuleMustBePresentToPreventStartupCrash` | `ModuleLayer` check — fails with the exact production stack trace if `jdk.net` is absent from the JRE |
| `jdkNetSocketsMustBeLoadable` | `Class.forName("jdk.net.Sockets")` — fails inside a jlink JRE that omits `jdk.net` |
| `shouldNotThrowNoClassDefFoundErrorWhenCredentialsPresent` | Full code path with dummy credentials — throws `NoClassDefFoundError: jdk/net/Sockets` without the fix, passes after |

Run locally:

```bash
mvn test -Dtest=CloudWatchAppenderTest
# Tests run: 6, Failures: 0, Errors: 0
```

#### 2. Container image verification — manual

Built the fixed image and verified `jdk.net` is present in the jlink JRE:

```bash
docker run --rm \
  -e LOGGING_LEVEL=info \
  -e ROOT_LOGGING_LEVEL=error \
  quay.io/kruize/autotune_operator:0.11.1 \
  /home/autotune/app/jre/bin/java --list-modules | grep jdk.net
# Output: jdk.net@25
```

#### 3. Deployment verification — manual, OpenShift dev cluster

Deployed the fixed image to OpenShift dev cluster with CloudWatch credentials pointing
at a dedicated dev AWS log group (`kruize-dev-logs` / `kruize-dev-stream`) on a
non-production AWS account with a scoped IAM user.

**Before fix:** pod entered `CrashLoopBackOff` with `NoClassDefFoundError: jdk/net/Sockets`.

**After fix:** pod reached `Running` state. The following line confirmed successful
CloudWatch setup:

```
INFO [main][CloudWatchAppender.java] - CloudWatch logging enabled — region: us-east-1,
log group: kruize-dev-logs, log stream: kruize-dev-stream, log level: INFO
```

Can also be verified by exec-ing into the running pod:

```bash
oc exec -it <pod> -n openshift-tuning -- \
  /home/autotune/app/jre/bin/java --list-modules | grep jdk.net
# Output: jdk.net@25
```

#### CVE testing
- Validated the quay scan report and ran the regression bucket as well to verify there's no new failure.

#### Release Notes
https://github.com/kruize/autotune/releases/tag/v0.11.1

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no: **0.11.1**
  - [ ] Is that image available in production or needs deployment? **Available**
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Update Kruize image tag references in ClowdApp and docker-compose configuration to align with the latest Kruize 0.11.1 release.