### PR TITLE
RHINENG-23426 Grafana panels for the API endpoints

### DIFF
--- a/dashboards/grafana-dashboard-insights-rosocp-general.configmap.yaml
+++ b/dashboards/grafana-dashboard-insights-rosocp-general.configmap.yaml
@@ -788,6 +788,85 @@ data:
         },
         {
           "datasource": {
+            "uid": "${datasource}"
+          },
+          "description": "A count of HTTP 5xx errors from the Container List endpoint",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 20
+          },
+          "id": 57,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(rosocp_http_5xx_total{url=\"/api/cost-management/v1/recommendations/openshift\"}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP 5xx Total - Container List",
+          "type": "stat"
+        },
+        {
+          "datasource": {
             "uid": "${cloudwatch}"
           },
           "fieldConfig": {
@@ -847,9 +926,9 @@ data:
             "overrides": []
           },
           "gridPos": {
-            "h": 7,
-            "w": 24,
-            "x": 0,
+            "h": 8,
+            "w": 13,
+            "x": 6,
             "y": 20
           },
           "id": 32,
@@ -884,12 +963,91 @@ data:
           "type": "timeseries"
         },
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "description": "A count of HTTP 4xx errors from the Container List endpoint",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 5,
+            "x": 19,
+            "y": 20
+          },
+          "id": 58,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(rosocp_http_4xx_total{url=\"/api/cost-management/v1/recommendations/openshift/container\"}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP 4xx Total - Container List",
+          "type": "stat"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 28
           },
           "id": 11,
           "panels": [],
@@ -937,7 +1095,7 @@ data:
             "h": 5,
             "w": 6,
             "x": 0,
-            "y": 28
+            "y": 29
           },
           "id": 30,
           "maxDataPoints": 100,
@@ -1016,7 +1174,7 @@ data:
             "h": 5,
             "w": 6,
             "x": 6,
-            "y": 28
+            "y": 29
           },
           "id": 8,
           "maxDataPoints": 100,
@@ -1128,7 +1286,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 34
           },
           "id": 29,
           "interval": "24h",
@@ -1171,7 +1329,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 41
+            "y": 42
           },
           "id": 40,
           "panels": [],
@@ -1219,7 +1377,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 42
+            "y": 43
           },
           "id": 43,
           "maxDataPoints": 100,
@@ -1298,7 +1456,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 6,
-            "y": 42
+            "y": 43
           },
           "id": 41,
           "maxDataPoints": 100,
@@ -1377,7 +1535,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 12,
-            "y": 42
+            "y": 43
           },
           "id": 42,
           "maxDataPoints": 100,
@@ -1456,7 +1614,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 42
+            "y": 43
           },
           "id": 46,
           "maxDataPoints": 100,
@@ -1535,7 +1693,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 0,
-            "y": 49
+            "y": 50
           },
           "id": 44,
           "maxDataPoints": 100,
@@ -1641,7 +1799,7 @@ data:
             "h": 7,
             "w": 12,
             "x": 6,
-            "y": 49
+            "y": 50
           },
           "id": 55,
           "options": {
@@ -1716,7 +1874,7 @@ data:
             "h": 7,
             "w": 6,
             "x": 18,
-            "y": 49
+            "y": 50
           },
           "id": 45,
           "maxDataPoints": 100,
@@ -1755,12 +1913,170 @@ data:
           "type": "stat"
         },
         {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "description": "A count of HTTP 5xx errors from the Namespace List endpoint",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 0,
+            "y": 57
+          },
+          "id": 59,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(rosocp_http_5xx_total{url=\"/api/cost-management/v1/recommendations/openshift/namespace\"}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP 5xx Total - Namespace List",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "${datasource}"
+          },
+          "description": "A count of HTTP 4xx errors from the Namespace List endpoint",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "text": "N/A"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 7,
+            "w": 6,
+            "x": 6,
+            "y": 57
+          },
+          "id": 60,
+          "maxDataPoints": 100,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "percentChangeColorMode": "standard",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "showPercentChange": false,
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "11.6.11",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${datasource}"
+              },
+              "editorMode": "code",
+              "expr": "sum(increase(rosocp_http_4xx_total{url=\"/api/cost-management/v1/recommendations/openshift/namespace\"}[$__range]))",
+              "legendFormat": "__auto",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP 4xx Total - Namespace List",
+          "type": "stat"
+        },
+        {
           "collapsed": false,
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 56
+            "y": 64
           },
           "id": 50,
           "panels": [],
@@ -1833,7 +2149,7 @@ data:
             "h": 9,
             "w": 9,
             "x": 0,
-            "y": 57
+            "y": 65
           },
           "id": 51,
           "options": {
@@ -1933,7 +2249,7 @@ data:
             "h": 9,
             "w": 8,
             "x": 9,
-            "y": 57
+            "y": 65
           },
           "id": 52,
           "options": {
@@ -2066,7 +2382,7 @@ data:
             "h": 9,
             "w": 7,
             "x": 17,
-            "y": 57
+            "y": 65
           },
           "id": 56,
           "options": {

--- a/internal/api/metrics.go
+++ b/internal/api/metrics.go
@@ -1,0 +1,45 @@
+package api
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	http4xxTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rosocp_http_4xx_total",
+		Help: "Total HTTP 4xx responses from the API",
+	}, []string{"url", "http_code"})
+	http5xxTotal = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "rosocp_http_5xx_total",
+		Help: "Total HTTP 5xx responses from the API",
+	}, []string{"url", "http_code"})
+)
+
+func recordHTTPStatusMetric(c echo.Context) {
+	status := c.Response().Status
+	if status < 400 {
+		return
+	}
+
+	code := strconv.Itoa(status)
+	path := c.Path()
+
+	switch {
+	case status >= 500:
+		http5xxTotal.WithLabelValues(path, code).Inc()
+	case status >= 400:
+		http4xxTotal.WithLabelValues(path, code).Inc()
+	}
+}
+
+func HTTPStatusMetricsMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		err := next(c)
+		recordHTTPStatusMetric(c)
+		return err
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -60,11 +60,11 @@ func StartAPIServer() {
 	app.File("/api/cost-management/v1/recommendations/openshift/openapi.json", "openapi.json")
 
 	v1 := app.Group("/api/cost-management/v1")
+	v1.Use(HTTPStatusMetricsMiddleware)
 	v1.Use(ros_middleware.Identity)
 	if cfg.RBACEnabled {
 		v1.Use(ros_middleware.Rbac)
 	}
-
 	registerRecommendationRoutes(v1)
 
 	s := http.Server{


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

- metrics have been added for 4xx and 5xx HTTP codes
- panels show count data for v1 endpoints for both codes wrt list endpoints

## Sample Metric for HTTP code 

<img width="1697" height="150" alt="image" src="https://github.com/user-attachments/assets/df9e2e57-f1a5-4ea9-a585-c4ea8e8ebb02" />

## Documentation update? :memo:

- [x] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [x] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

The url for the custom Grafana panel used to testing changes is available in the JIRA card description.

## Summary by Sourcery

Introduce HTTP error metrics collection for the v1 cost-management API and surface these metrics in the Grafana dashboard via new panels for container and namespace list endpoints.

New Features:
- Add Grafana stat panels showing aggregated HTTP 4xx and 5xx counts for v1 container and namespace list API endpoints.

Enhancements:
- Instrument the v1 cost-management API group with Prometheus-based middleware to record HTTP 4xx and 5xx status code metrics per endpoint path.
- Adjust Grafana dashboard layout to accommodate new error metrics panels while preserving existing content visibility.