### PR TITLE
RHINENG-28795 Upgrade to Kruize 0.11.1

### DIFF
--- a/kruize-clowdapp.yaml
+++ b/kruize-clowdapp.yaml
@@ -241,7 +241,7 @@ parameters:
 - description: Kruize image tag
   name: KRUIZE_IMAGE_TAG
   required: true
-  value: "bd937f6"
+  value: "d1f0140"
 - description: Kruize server port
   name: KRUIZE_PORT
   required: true

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     depends_on:
        - kafka
   kruize-autotune:
-    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:bd937f6
+    image: quay.io/redhat-services-prod/kruize-autotune-tenant/autotune:d1f0140
     volumes:
       - ./cdappconfig.json:/tmp/cdappconfig.json:Z
     ports:


### PR DESCRIPTION
## Why do we need this change? :thought_balloon:

Upgrade to Kruize 0.11.1, aims to resolve an Cloudwatch library issue with Kruize 0.11

## Documentation update? :memo:

- [ ] Yes
- [x] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [x] Does this change depend on specific version of Kruize
  - If yes what is the version no: Kruize 0.11.1
  - [x] Is that image available in production or needs deployment?
- [x] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:


### Summary by Sourcery

Build:
- Update Kruize image tag parameter to point to the new autotune image version in clowdapp and docker-compose configuration.