### PR TITLE
fix: configure ros-ocp-backend-onprem tekton for hermetic builds

### DIFF
--- a/.tekton/ros-ocp-backend-onprem-pull-request.yaml
+++ b/.tekton/ros-ocp-backend-onprem-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "main"
+      == "release-onprem"
   labels:
     appstudio.openshift.io/application: ros-ocp-backend-onprem
     appstudio.openshift.io/component: ros-ocp-backend-onprem
@@ -30,6 +30,16 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
+  - name: build-args
+    value:
+    - IMAGE_NAME=costmanagement/costmanagement-ros-ocp-backend-rhel9
+    - VERSION=1
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/.tekton/ros-ocp-backend-onprem-push.yaml
+++ b/.tekton/ros-ocp-backend-onprem-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "main"
+      == "release-onprem"
   labels:
     appstudio.openshift.io/application: ros-ocp-backend-onprem
     appstudio.openshift.io/component: ros-ocp-backend-onprem
@@ -27,6 +27,16 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "."}'
+  - name: build-source-image
+    value: "true"
+  - name: build-args
+    value:
+    - IMAGE_NAME=costmanagement/costmanagement-ros-ocp-backend-rhel9
+    - VERSION=1
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,20 @@ COPY --from=builder /go/src/app/go_version_details ./go_version_details
 COPY migrations ./migrations
 COPY openapi.json ./openapi.json
 COPY resource_optimization_openshift.json ./resource_optimization_openshift.json
+
+ARG IMAGE_NAME
+ARG VERSION
+LABEL summary="Resource Optimization for OpenShift backend for on-premise deployments" \
+    description="Red Hat Resource Optimization for OpenShift backend for on-premise deployments" \
+    io.k8s.description="Red Hat Resource Optimization for OpenShift backend for on-premise deployments" \
+    io.k8s.display-name="Resource Optimization for OpenShift Backend" \
+    com.redhat.component="costmanagement-ros-ocp-backend-rhel9-container" \
+    name="$IMAGE_NAME" \
+    version="$VERSION" \
+    release="1" \
+    vendor="Red Hat, Inc." \
+    distribution-scope="public" \
+    cpe="cpe:/a:redhat:cost_management_on_premise:1::el9" \
+    maintainer="Red Hat Cost Management Services <cost-mgmt@redhat.com>"
+
 USER 1001


### PR DESCRIPTION
- Set hermetic build to true
- Add gomod prefetch for hermetic builds
- Enable source image build
- Add IMAGE_NAME and VERSION build args
- Set CEL expression to release-onprem branch

## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHINENG-XXX - Title
2. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Configure ros-ocp-backend-onprem builds for hermetic image creation and release-onprem pipeline triggers.

Bug Fixes:
- Configure on-premises pull-request and push Tekton pipelines to target the release-onprem branch.

Enhancements:
- Enable hermetic container builds with Go module dependency prefetching and source image generation.
- Add standardized image name and version metadata to the on-premises backend container image.