### PR TITLE
Fix ros ocp backend onprem tekton

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,14 @@ FROM registry.access.redhat.com/ubi9/go-toolset:1.26.5 AS builder
 WORKDIR /go/src/app
 COPY . .
 USER 0
-RUN go get -d ./... && \
+# Source prefetch env to use hermetic cache for Go modules
+RUN if [ -f /cachi2/cachi2.env ]; then . /cachi2/cachi2.env; fi && \
+    go get -d ./... && \
     go build -o rosocp rosocp.go && \
     echo "$(go version)" > go_version_details
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
-RUN microdnf -y update \
-    --disableplugin=subscription-manager
 COPY --from=builder /go/src/app/rosocp ./rosocp
 COPY --from=builder /go/src/app/go_version_details ./go_version_details
 COPY migrations ./migrations


### PR DESCRIPTION
## PR Title :boom:

Please title this PR with a summary of the change, along with the JIRA card number.

Suggested formats: 

1. Fixes/Refs #RHINENG-XXX - Title
2. RHINENG-XXX Title 

Feel free to remove this section from PR description once done.

## Why do we need this change? :thought_balloon:

Please include the __context of this change__ here. If the change depends on Kruize add details about that as well!

## Documentation update? :memo:

- [ ] Yes
- [ ] No

## Security Checklist :lock:

Upon raising this PR please go through [RedHatInsights/secure-coding-checklist](https://github.com/RedHatInsights/secure-coding-checklist)

## :guardsman: Checklist :dart:

- [ ] Does this change depend on specific version of Kruize
  - If yes what is the version no:
  - [ ] Is that image available in production or needs deployment?
- [ ] Bugfix
- [ ] New Feature
- [ ] Refactor
- [ ] Unittests Added
- [ ] DRY code
- [ ] Dependency Added
- [ ] DB Migration Added

## Additional :mega:

Feel free to add any other relevant details such as __links, notes, screenshots__, here.

## Summary by Sourcery

Enable hermetic RPM-aware builds for the on-premises ROS OCP backend Tekton pipelines.

Bug Fixes:
- Enable RPM dependency prefetching for the on-premises ROS OCP backend Tekton pull-request and push pipelines.

Build:
- Add RPM repository and lockfile metadata to support hermetic pipeline builds.